### PR TITLE
Optimize Sylvan float bench

### DIFF
--- a/src/Sep.ComparisonBenchmarks/Sep.ComparisonBenchmarks.csproj
+++ b/src/Sep.ComparisonBenchmarks/Sep.ComparisonBenchmarks.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="csFastFloat" Version="4.1.0" />
     <PackageReference Include="CsvHelper" Version="30.0.1" />
     <PackageReference Include="Sylvan.Common" Version="0.4.2" />
-    <PackageReference Include="Sylvan.Data.Csv" Version="1.3.1" />
+    <PackageReference Include="Sylvan.Data.Csv" Version="1.3.2" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
This applies some optimizations to the Sylvan library in the floats benchmarks:
- updates to the latest version of the library
- lookup ordinals outside the loop. I don't cache ordinal lookups, so this was rather costly.
- use the csfastfloat library for float parsing. Sylvan allows accessing the span of the field to support scenarios like this.
- use external, pooled buffer, which is mostly a memory optimization.

Running the "floats" family of benchmarks now produces some interesting results on my machine, which is running an Intel i7 7700K. I can't compete on the ARM side, as I have no hardware to test on. I'll be interested to see if your results match mine.