### PR TITLE
Remove Debugger.Break 🤦‍♂️, SepWriter always writes line ending, expand test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ var expected = """
                A;B;C;D;E;F
                Sep;🚀;2;0.6;1;5
                CSV;✅;4;1.1;2;15
-               """;
+               
+               """;                       // Empty line at end is for line ending,
+                                          // which is always written.
 Assert.AreEqual(expected, writer.ToString());
 
 // Above example code is for demonstration purposes only.
@@ -850,7 +852,8 @@ var text = """
            A;B;C;D;E;F
            Sep;🚀;1;1.2;0.1;0.5
            CSV;✅;2;2.2;0.2;1.5
-           """;
+           
+           """; // Empty line at end is for line ending
 
 using var reader = Sep.Reader().FromText(text);
 using var writer = reader.Spec.Writer().ToText();

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyVersion>0.2.0</AssemblyVersion>
     <FileVersion>0.2.0</FileVersion>
-    <InformationalVersion>$(FileVersion)-preview.2</InformationalVersion>
+    <InformationalVersion>$(FileVersion)-preview.3</InformationalVersion>
     <PackageVersion>$(InformationalVersion)</PackageVersion>
 
     <Company>nietras</Company>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -30,6 +30,7 @@
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
 
+    <DefineConstants Condition="'$(Configuration)'=='Release'">$(DefineConstants);SEPBENCHSLOWONES</DefineConstants>
     <DefineConstants Condition="'$(Configuration)'=='Debug'">$(DefineConstants);SEPASSERT</DefineConstants>
     <DefineConstants Condition="'$(Configuration)'=='Debug'">$(DefineConstants);SEPTRACE</DefineConstants>
     <DefineConstants Condition="'$(Configuration)'=='Debug'">$(DefineConstants);SEPREADERASSERT</DefineConstants>

--- a/src/Sep.Benchmarks/Runner.cs
+++ b/src/Sep.Benchmarks/Runner.cs
@@ -70,9 +70,6 @@ public static class Runner
                 var valuesFromIndeces = colsFromIndeces.Parse<double>();
                 var valuesFromNames = colsFromNames.Parse<double>();
 
-                //if (line == 10)
-                //    Debugger.Break();
-
                 using var writeRow = writer.NewRow();
                 writeRow[C.Name].Set(name);
                 writeRow[C.SByte].Format(i8);

--- a/src/Sep.ComparisonBenchmarks/FloatsReaderBench.cs
+++ b/src/Sep.ComparisonBenchmarks/FloatsReaderBench.cs
@@ -1,5 +1,4 @@
-﻿#define BENCH_SLOW_ONES
-using System;
+﻿using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Globalization;
@@ -88,7 +87,7 @@ public class RowFloatsReaderBench : FloatsReaderBench
         finally { ArrayPool<char>.Shared.Return(buffer); }
     }
 
-#if BENCH_SLOW_ONES
+#if SEPBENCHSLOWONES
     [Benchmark]
 #endif
     public void ReadLine_()
@@ -101,7 +100,7 @@ public class RowFloatsReaderBench : FloatsReaderBench
         }
     }
 
-#if BENCH_SLOW_ONES
+#if SEPBENCHSLOWONES
     [Benchmark]
 #endif
     public void CsvHelper()
@@ -173,7 +172,7 @@ public class ColsFloatsReaderBench : FloatsReaderBench
         finally { ArrayPool<char>.Shared.Return(buffer); }
     }
 
-#if BENCH_SLOW_ONES
+#if SEPBENCHSLOWONES
     [Benchmark]
 #endif
     public void ReadLine_()
@@ -190,7 +189,7 @@ public class ColsFloatsReaderBench : FloatsReaderBench
         }
     }
 
-#if BENCH_SLOW_ONES
+#if SEPBENCHSLOWONES
     [Benchmark]
 #endif
     public void CsvHelper()
@@ -305,7 +304,7 @@ public class FloatsFloatsReaderBench : FloatsReaderBench
         finally { ArrayPool<char>.Shared.Return(buffer); }
     }
 
-#if BENCH_SLOW_ONES
+#if SEPBENCHSLOWONES
     [Benchmark]
 #endif
     public double ReadLine_()
@@ -357,7 +356,7 @@ public class FloatsFloatsReaderBench : FloatsReaderBench
         return sum / count;
     }
 
-#if BENCH_SLOW_ONES
+#if SEPBENCHSLOWONES
     [Benchmark]
 #endif
     public double CsvHelper()

--- a/src/Sep.ComparisonBenchmarks/PackageAssetsBench.cs
+++ b/src/Sep.ComparisonBenchmarks/PackageAssetsBench.cs
@@ -1,5 +1,4 @@
 ﻿#define USE_STRING_POOLING
-#define BENCH_SLOW_ONES
 using System;
 using System.Buffers;
 using System.Collections.Generic;
@@ -100,7 +99,7 @@ public class RowPackageAssetsBench : PackageAssetsBench
         finally { ArrayPool<char>.Shared.Return(buffer); }
     }
 
-#if BENCH_SLOW_ONES
+#if SEPBENCHSLOWONES
     [Benchmark]
 #endif
     public void ReadLine_()
@@ -113,7 +112,7 @@ public class RowPackageAssetsBench : PackageAssetsBench
         }
     }
 
-#if BENCH_SLOW_ONES
+#if SEPBENCHSLOWONES
     [Benchmark]
 #endif
     public void CsvHelper()
@@ -190,7 +189,7 @@ public class ColsPackageAssetsBench : PackageAssetsBench
         finally { ArrayPool<char>.Shared.Return(buffer); }
     }
 
-#if BENCH_SLOW_ONES
+#if SEPBENCHSLOWONES
     [Benchmark]
 #endif
     public void ReadLine_()
@@ -207,7 +206,7 @@ public class ColsPackageAssetsBench : PackageAssetsBench
         }
     }
 
-#if BENCH_SLOW_ONES
+#if SEPBENCHSLOWONES
     [Benchmark]
 #endif
     public void CsvHelper()
@@ -303,7 +302,7 @@ public class AssetPackageAssetsBench : PackageAssetsBench
         finally { ArrayPool<char>.Shared.Return(buffer); }
     }
 
-#if BENCH_SLOW_ONES
+#if SEPBENCHSLOWONES
     [Benchmark]
 #endif
     public void ReadLine_()
@@ -319,7 +318,7 @@ public class AssetPackageAssetsBench : PackageAssetsBench
         }
     }
 
-#if BENCH_SLOW_ONES
+#if SEPBENCHSLOWONES
     [Benchmark]
 #endif
     public void CsvHelper()

--- a/src/Sep.Test/ReadMeTest.cs
+++ b/src/Sep.Test/ReadMeTest.cs
@@ -49,7 +49,9 @@ public class ReadMeTest
                        A;B;C;D;E;F
                        Sep;🚀;2;0.6;1;5
                        CSV;✅;4;1.1;2;15
-                       """;
+                       
+                       """;                       // Empty line at end is for line ending,
+                                                  // which is always written.
         Assert.AreEqual(expected, writer.ToString());
 
         // Above example code is for demonstration purposes only.
@@ -178,7 +180,8 @@ public class ReadMeTest
                    A;B;C;D;E;F
                    Sep;🚀;1;1.2;0.1;0.5
                    CSV;✅;2;2.2;0.2;1.5
-                   """;
+                   
+                   """; // Empty line at end is for line ending
 
         using var reader = Sep.Reader().FromText(text);
         using var writer = reader.Spec.Writer().ToText();

--- a/src/Sep.Test/SepReaderTest.cs
+++ b/src/Sep.Test/SepReaderTest.cs
@@ -394,6 +394,28 @@ public class SepReaderTest
         Assert.AreEqual(lengthB, colNames[1].Length);
     }
 
+    [DataTestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
+    public void SepReaderTest_CarriageReturnLineFeedEvenOrOdd_ToEnsureLineFeedReadAfterCarriageReturn(bool even)
+    {
+#if SEPREADERTRACE // Don't run really long with tracing enabled 😅
+        const int lineEndingCount = 167;
+#else
+        const int lineEndingCount = 1267 + 64 * 1024;
+#endif
+        var lineEnding = "\r\n";
+        var lineEndingStartIndex = (even ? 0 : 1);
+        var sb = new StringBuilder(lineEndingCount * lineEnding.Length + lineEndingStartIndex);
+        // Add space if odd
+        if (!even) { sb.Append(' '); };
+        sb.Insert(lineEndingStartIndex, lineEnding, lineEndingCount);
+        var text = sb.ToString();
+
+        using var reader = Sep.Reader(o => o with { HasHeader = false }).FromText(text);
+        foreach (var row in reader) { }
+    }
+
     [TestMethod]
     public void SepReaderTest_MaximumColCount()
     {

--- a/src/Sep.Test/SepReaderWriterTest.cs
+++ b/src/Sep.Test/SepReaderWriterTest.cs
@@ -94,7 +94,9 @@ public class SepReaderWriterTest
     [DataRow(2)]
     [DataRow(3)]
     [DataRow(117)]
+#if !SEPREADERTRACE
     [DataRow(17847)]
+#endif
     public void SepReaderWriterTest_CopySingleEmptyColumn(int rowCountWithHeader)
     {
         var newLine = Environment.NewLine;

--- a/src/Sep.Test/SepReaderWriterTest.cs
+++ b/src/Sep.Test/SepReaderWriterTest.cs
@@ -83,6 +83,39 @@ public class SepReaderWriterTest
         Assert.AreEqual(expected, writer.ToString());
     }
 
+    [DataTestMethod]
+    [DataRow(0)]
+    [DataRow(1)]
+    [DataRow(2)]
+    [DataRow(3)]
+    [DataRow(117)]
+    [DataRow(17847)]
+    public void SepReaderWriterTest_CopySingleEmptyColumn(int rowCount)
+    {
+        var newLine = Environment.NewLine;
+        var expected = new StringBuilder(rowCount * newLine.Length)
+            .Insert(0, newLine, rowCount).ToString();
+
+        var lineEndings = new[] { "\r", "\r\n", "\n" };
+        foreach (var lineEnding in lineEndings)
+        {
+            var src = new StringBuilder(rowCount * lineEnding.Length)
+                .Insert(0, lineEnding, rowCount).ToString();
+
+            using var reader = Sep.Reader(o => o with { HasHeader = false }).FromText(src);
+            using var writer = reader.Spec.Writer().ToText();
+            foreach (var readRow in reader)
+            {
+                using var writeRow = writer.NewRow();
+                writeRow[""].Set(string.Empty);
+            }
+            // Assert
+            var actual = writer.ToString();
+            Assert.AreEqual(expected, actual);
+        }
+    }
+
+
     void AssertCopyColumns(string text)
     {
         ArgumentNullException.ThrowIfNull(text);

--- a/src/Sep.Test/SepReaderWriterTest.cs
+++ b/src/Sep.Test/SepReaderWriterTest.cs
@@ -19,12 +19,15 @@ public class SepReaderWriterTest
     [DataTestMethod]
     [DataRow(@"")]
     [DataRow(@"C1
-\n")]
+
+")]
     [DataRow(@"C1,C2
-123,456")]
+123,456
+")]
     [DataRow(@"C1;C2
 123;456
-789;012")]
+789;012
+")]
     public void SepReaderWriterTest_CopyColumnsIfAnyRows(string text) =>
         AssertCopyColumns(text);
 
@@ -40,11 +43,12 @@ public class SepReaderWriterTest
         {
             var sb = new StringBuilder(length);
             sb.Append('H');
+            sb.AppendLine();
             var i = 0;
             while (sb.Length < length)
             {
-                sb.AppendLine();
                 sb.Append((char)('a' + i % ('z' - 'a')));
+                sb.AppendLine();
                 ++i;
             }
             var text = sb.ToString();
@@ -79,6 +83,7 @@ public class SepReaderWriterTest
                        A;B;C
                        x;2;0.55
                        y;4;1.1
+                       
                        """;
         Assert.AreEqual(expected, writer.ToString());
     }
@@ -90,31 +95,38 @@ public class SepReaderWriterTest
     [DataRow(3)]
     [DataRow(117)]
     [DataRow(17847)]
-    public void SepReaderWriterTest_CopySingleEmptyColumn(int rowCount)
+    public void SepReaderWriterTest_CopySingleEmptyColumn(int rowCountWithHeader)
     {
         var newLine = Environment.NewLine;
-        var expected = new StringBuilder(rowCount * newLine.Length)
-            .Insert(0, newLine, rowCount).ToString();
+        var expected = new StringBuilder(rowCountWithHeader * newLine.Length)
+            .Insert(0, newLine, rowCountWithHeader).ToString();
 
         var lineEndings = new[] { "\r", "\r\n", "\n" };
         foreach (var lineEnding in lineEndings)
         {
-            var src = new StringBuilder(rowCount * lineEnding.Length)
-                .Insert(0, lineEnding, rowCount).ToString();
+            var src = new StringBuilder(rowCountWithHeader * lineEnding.Length)
+                .Insert(0, lineEnding, rowCountWithHeader).ToString();
 
-            using var reader = Sep.Reader(o => o with { HasHeader = false }).FromText(src);
+            using var reader = Sep.Reader().FromText(src);
             using var writer = reader.Spec.Writer().ToText();
+            var actualRowCountWithHeader = reader.HasHeader ? 1 : 0;
             foreach (var readRow in reader)
             {
-                using var writeRow = writer.NewRow();
-                writeRow[""].Set(string.Empty);
+                using var writeRow = writer.NewRow(readRow);
+                ++actualRowCountWithHeader;
             }
             // Assert
+            Assert.AreEqual(rowCountWithHeader, actualRowCountWithHeader);
             var actual = writer.ToString();
-            Assert.AreEqual(expected, actual);
+            // If no rows only header then writer won't write header, this is by
+            // design given how the API looks. To fix that we need to initialize
+            // writer header somehow. This is something that needs to be
+            // considered going forward. A source with empty column name and no
+            // rows is considered a rare case.
+            var overrideExpected = rowCountWithHeader != 1 ? expected : string.Empty;
+            Assert.AreEqual(overrideExpected, actual);
         }
     }
-
 
     void AssertCopyColumns(string text)
     {

--- a/src/Sep.Test/SepWriterColTest.cs
+++ b/src/Sep.Test/SepWriterColTest.cs
@@ -112,7 +112,7 @@ public class SepWriterColTest
         }
         if (expectedColValue is not null)
         {
-            var expectedText = $"{ColName}{Environment.NewLine}{expectedColValue}";
+            var expectedText = $"{ColName}{Environment.NewLine}{expectedColValue}{Environment.NewLine}";
             var actualText = writer.ToString();
             Assert.AreEqual(expectedText, actualText);
         }

--- a/src/Sep.Test/SepWriterColsTest.cs
+++ b/src/Sep.Test/SepWriterColsTest.cs
@@ -18,6 +18,7 @@ public class SepWriterColsTest
                             A;B;C
                             10;11;12
                             20;21;22
+                            
                             """;
 
     [TestMethod]
@@ -48,6 +49,7 @@ public class SepWriterColsTest
                                 A;B;C
                                 10;03;12
                                 20;21;1.2
+                                
                                 """;
         Assert.AreEqual(expected, writer.ToString());
     }

--- a/src/Sep.Test/SepWriterReaderTest.cs
+++ b/src/Sep.Test/SepWriterReaderTest.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace nietras.SeparatedValues.Test;
+
+[TestClass]
+public class SepWriterReaderTest
+{
+    [DataTestMethod]
+    [DataRow(0)]
+    [DataRow(1)]
+    [DataRow(2)]
+    [DataRow(3)]
+    [DataRow(117)]
+    [DataRow(17847)]
+    public void SepWriterReaderTest_EmptyColumn(int rowCount)
+    {
+        using var writer = Sep.Writer().ToText();
+        for (var i = 0; i < rowCount; i++)
+        {
+            using var writeRow = writer.NewRow();
+            writeRow[string.Empty].Set(string.Empty);
+        }
+
+        var actualRowCount = 0;
+        using var reader = Sep.Reader().FromText(writer.ToString());
+        foreach (var readRow in reader)
+        {
+            Assert.AreEqual(string.Empty, readRow[string.Empty].ToString());
+            ++actualRowCount;
+        }
+        // Assert
+        Assert.AreEqual(rowCount, actualRowCount);
+    }
+}

--- a/src/Sep.Test/SepWriterReaderTest.cs
+++ b/src/Sep.Test/SepWriterReaderTest.cs
@@ -11,7 +11,9 @@ public class SepWriterReaderTest
     [DataRow(2)]
     [DataRow(3)]
     [DataRow(117)]
+#if !SEPREADERTRACE
     [DataRow(17847)]
+#endif
     public void SepWriterReaderTest_EmptyColumn(int rowCount)
     {
         using var writer = Sep.Writer().ToText();

--- a/src/Sep.Test/SepWriterRowTest.cs
+++ b/src/Sep.Test/SepWriterRowTest.cs
@@ -14,13 +14,13 @@ public class SepWriterRowTest
     [TestMethod]
     public void SepWriterRowTest_Indexer_ColIndex_After_ColName()
     {
-        Run(row => { row["A"].Set("1"); row[0].Set("11"); }, $"A{NL}11");
+        Run(row => { row["A"].Set("1"); row[0].Set("11"); }, $"A{NL}11{NL}");
         Run(row =>
             {
                 row["A"].Set("1"); row["B"].Set("2");
                 row[1].Set("22");
             },
-            $"A;B{NL}1;22");
+            $"A;B{NL}1;22{NL}");
     }
 
     [TestMethod]
@@ -34,7 +34,7 @@ public class SepWriterRowTest
             {
                 row[colNames.AsSpan()].Set(colValues0.AsSpan());
                 row[colIndices.AsSpan()].Set(colValues1.AsSpan());
-            }, $"A;B{NL}11;22");
+            }, $"A;B{NL}11;22{NL}");
     }
 
     [TestMethod]
@@ -48,15 +48,15 @@ public class SepWriterRowTest
         {
             row[colNames.AsSpan()].Set(colValues0.AsSpan());
             row[colIndices.AsSpan()].Set(colValues1.AsSpan());
-        }, $"A;B{NL}1;2");
+        }, $"A;B{NL}1;2{NL}");
     }
 
     [TestMethod]
     public void SepWriterRowTest_Indexer_ColName()
     {
-        Run(row => row["A"].Set("1"), $"A{NL}1");
+        Run(row => row["A"].Set("1"), $"A{NL}1{NL}");
         Run(row => { row["A"].Set("1"); row["B"].Set("2"); },
-            $"A;B{NL}1;2");
+            $"A;B{NL}1;2{NL}");
     }
 
     [TestMethod]
@@ -64,7 +64,7 @@ public class SepWriterRowTest
     {
         var colNames = new string[] { "A", "B" };
         var colValues = new string[] { "1", "2" };
-        Run(row => row[colNames.AsSpan()].Set(colValues.AsSpan()), $"A;B{NL}1;2");
+        Run(row => row[colNames.AsSpan()].Set(colValues.AsSpan()), $"A;B{NL}1;2{NL}");
     }
 
     [TestMethod]
@@ -72,7 +72,7 @@ public class SepWriterRowTest
     {
         var colNames = Array.Empty<string>();
         var colValues = Array.Empty<string>();
-        Run(row => row[colNames.AsSpan()].Set(colValues.AsSpan()), $"{NL}");
+        Run(row => row[colNames.AsSpan()].Set(colValues.AsSpan()), $"{NL}{NL}");
     }
 
     [TestMethod]
@@ -80,7 +80,7 @@ public class SepWriterRowTest
     {
         IReadOnlyList<string> colNames = new string[] { "A", "B" };
         IReadOnlyList<string> colValues = new string[] { "1", "2" };
-        Run(row => row[colNames].Set(colValues), $"A;B{NL}1;2");
+        Run(row => row[colNames].Set(colValues), $"A;B{NL}1;2{NL}");
     }
 
     [TestMethod]
@@ -88,7 +88,7 @@ public class SepWriterRowTest
     {
         IReadOnlyList<string> colNames = Array.Empty<string>();
         IReadOnlyList<string> colValues = Array.Empty<string>();
-        Run(row => row[colNames].Set(colValues), $"{NL}");
+        Run(row => row[colNames].Set(colValues), $"{NL}{NL}");
     }
 
     [TestMethod]
@@ -105,7 +105,7 @@ public class SepWriterRowTest
     {
         var colNames = new string[] { "A", "B" };
         var colValues = new string[] { "1", "2" };
-        Run(row => row[colNames].Set(colValues), $"A;B{NL}1;2");
+        Run(row => row[colNames].Set(colValues), $"A;B{NL}1;2{NL}");
     }
 
     [TestMethod]
@@ -113,7 +113,7 @@ public class SepWriterRowTest
     {
         var colNames = Array.Empty<string>();
         var colValues = Array.Empty<string>();
-        Run(row => row[colNames].Set(colValues), $"{NL}");
+        Run(row => row[colNames].Set(colValues), $"{NL}{NL}");
     }
 
     [TestMethod]

--- a/src/Sep.Test/SepWriterTest.cs
+++ b/src/Sep.Test/SepWriterTest.cs
@@ -33,6 +33,7 @@ public class SepWriterTest
         }
         var expected =
 @"
+
 ";
         Assert.AreEqual(expected, writer.ToString());
     }
@@ -47,7 +48,8 @@ public class SepWriterTest
         }
         var expected =
 @"A
-1";
+1
+";
         Assert.AreEqual(expected, writer.ToString());
     }
 
@@ -71,7 +73,8 @@ public class SepWriterTest
         var expected =
 @"A;B;C
 1;2;34
- 23;3;65";
+ 23;3;65
+";
         Assert.AreEqual(expected, writer.ToString());
     }
 
@@ -100,7 +103,8 @@ public class SepWriterTest
         var expected =
 @"A;B;C
 1;2;34
- 23;3;65";
+ 23;3;65
+";
         Assert.AreEqual(expected, writer.ToString());
     }
 
@@ -140,7 +144,8 @@ public class SepWriterTest
         // Expected output should only be valid rows
         var expected =
 @"A
-1";
+1
+";
         Assert.AreEqual(expected, writer.ToString());
     }
 
@@ -164,7 +169,8 @@ public class SepWriterTest
         // Expected output should only be valid rows
         var expected =
 @"A;B
-1;2";
+1;2
+";
         Assert.AreEqual(expected, writer.ToString());
     }
 
@@ -185,6 +191,7 @@ public class SepWriterTest
         Assert.AreEqual("""
                         A
                         1
+                        
                         """, writer.ToString());
     }
 
@@ -200,6 +207,7 @@ public class SepWriterTest
         Assert.AreEqual("""
                         A
                         1
+                        
                         """, File.ReadAllText(fileName));
         File.Delete(fileName);
     }

--- a/src/Sep/SepReader.cs
+++ b/src/Sep/SepReader.cs
@@ -195,7 +195,6 @@ public partial class SepReader : IDisposable
 
         var endOfFile = false;
     LOOP:
-        if (_rowIndex == 56) { Debugger.Break(); }
         CheckPoint($"{nameof(_parser.Parse)} BEFORE");
 
         var rowLineEndingOffset = 0;

--- a/src/Sep/SepWriter.cs
+++ b/src/Sep/SepWriter.cs
@@ -73,6 +73,7 @@ public partial class SepWriter : IDisposable
                 _colNamesHeader[colIndex] = name;
                 notFirstHeader = true;
             }
+            _writer.WriteLine();
             _headerWritten = true;
         }
         else
@@ -89,7 +90,6 @@ public partial class SepWriter : IDisposable
         }
 
         // New Row
-        _writer.WriteLine();
         if (cols.Count > 0)
         {
             var notFirst = false;
@@ -108,6 +108,8 @@ public partial class SepWriter : IDisposable
                 notFirst = true;
             }
         }
+        _writer.WriteLine();
+
         _newRowActive = false;
     }
 


### PR DESCRIPTION
* Remove left-over Debugger.Break in `SepReader`
* Minor breaking change to `SepWriter` now always writes line ending for header and row to ensure row count consistent for empty columns.