### PR TITLE
Add SepReader.Cols.ParseToArray/ToStrings/ToStringsArray, Improve Debuggability

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,8 +282,8 @@ public bool DisableColCountCheck { get; init; }
 
 #### SepReader Debuggability
 Debuggability is an important part of any library and while this is still a work
-in progress for Sep, `SepReader` does have a unique feature when looking at it's
-row in a debug context. Given the below example code:
+in progress for Sep, `SepReader` does have a unique feature when looking at it
+and it's row or cols in a debug context. Given the below example code:
 ```csharp
 var text = """
            Key;Value
@@ -304,8 +304,16 @@ foreach (var row in reader)
     Debug.WriteLine(col.ToString());
 }
 ```
-and you are hovering over `row` when the break is triggered then this will show
-something like:
+and you are hovering over `reader` when the break is triggered then this will
+show something like:
+```
+String Length=55
+```
+That is, it will show information of the source for the reader, in this case a
+string of length 55.
+
+##### SepReader.Row Debuggability
+If you are hovering over `row` then this will show something like:
 ```
   2:[5..9] = "B;\"Apple\r\nBanana\r\nOrange\r\nPear\""
 ```
@@ -328,6 +336,8 @@ triangle) you will see each column of the row similar to below.
 00:'Key'   = "B"
 01:'Value' = "\"Apple\r\nBanana\r\nOrange\r\nPear\""
 ```
+
+##### SepReader.Col Debuggability
 If you hover over `col` you should see:
 ```
 "\"Apple\r\nBanana\r\nOrange\r\nPear\""

--- a/README.md
+++ b/README.md
@@ -320,6 +320,13 @@ that makes Sep a bit slower but which is a price considered worth paying.
 > GitHub doesn't show line numbers in code blocks so consider copying the
 > example text to notepad or similar to see the effect.
 
+Additionally, if you expand the `row` in the debugger (e.g. via the small
+triangle) you will see each column of the row similar to below.
+```
+00:'Key'   = "B"
+01:'Value' = "\"Apple\r\nBanana\r\nOrange\r\nPear\""
+``` 
+
 #### Why SepReader Is Not IEnumerable and LINQ Compatible
 As mentioned earlier Sep only allows enumeration and access to one row at a time
 and `SepReader.Row` is just a simple *facade* or indirection to the underlying

--- a/README.md
+++ b/README.md
@@ -298,18 +298,20 @@ var text = """
 using var reader = Sep.Reader().FromText(text);
 foreach (var row in reader)
 {
-    // Hover over row when breaking here
+    // Hover over reader, row or col when breaking here
+    var col = row[1];
     if (Debugger.IsAttached && row.RowIndex == 2) { Debugger.Break(); }
+    Debug.WriteLine(col.ToString());
 }
 ```
 and you are hovering over `row` when the break is triggered then this will show
 something like:
 ```
-  2:[5..9] = 'B;"Apple\r\nBanana\r\nOrange\r\nPear"
+  2:[5..9] = "B;\"Apple\r\nBanana\r\nOrange\r\nPear\""
 ```
 This has the format shown below. 
 ```
-<ROWINDEX>:[<LINENUMBERRANGE>] = '<ROW>'
+<ROWINDEX>:[<LINENUMBERRANGE>] = "<ROW>"
 ```
 Note how this shows line number range `[FromIncl..ToExcl]`, as in C# [range
 expression](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-8.0/ranges#systemrange),
@@ -325,7 +327,11 @@ triangle) you will see each column of the row similar to below.
 ```
 00:'Key'   = "B"
 01:'Value' = "\"Apple\r\nBanana\r\nOrange\r\nPear\""
-``` 
+```
+If you hover over `col` you should see:
+```
+"\"Apple\r\nBanana\r\nOrange\r\nPear\""
+```
 
 #### Why SepReader Is Not IEnumerable and LINQ Compatible
 As mentioned earlier Sep only allows enumeration and access to one row at a time

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyVersion>0.2.0</AssemblyVersion>
-    <FileVersion>0.2.4</FileVersion>
+    <FileVersion>0.2.5</FileVersion>
     <InformationalVersion>$(FileVersion)</InformationalVersion>
     <PackageVersion>$(InformationalVersion)</PackageVersion>
 

--- a/src/Sep.Test/ReadMeTest.cs
+++ b/src/Sep.Test/ReadMeTest.cs
@@ -79,8 +79,10 @@ public class ReadMeTest
         using var reader = Sep.Reader().FromText(text);
         foreach (var row in reader)
         {
-            // Hover over row when breaking here
+            // Hover over reader, row or col when breaking here
+            var col = row[1];
             if (Debugger.IsAttached && row.RowIndex == 2) { Debugger.Break(); }
+            Debug.WriteLine(col.ToString());
         }
     }
 

--- a/src/Sep.Test/SepReaderColTest.cs
+++ b/src/Sep.Test/SepReaderColTest.cs
@@ -78,6 +78,22 @@ public class SepReaderColTest
         AssertTryParseOutFloats(o => o with { CultureInfo = null, DisableFastFloat = true });
     }
 
+#if NET8_0_OR_GREATER
+    // string unfortunately did not implement ISpanParsable until .NET 8
+
+    [TestMethod]
+    public void SepReaderColTest_Parse_String()
+    {
+        Run(col => Assert.AreEqual(ColText, col.Parse<string>()));
+    }
+
+    [TestMethod]
+    public void SepReaderColTest_TryParse_Out_String()
+    {
+        Run(col => Assert.AreEqual(ColText, col.TryParse<string>(out var v) ? v : null));
+    }
+#endif
+
     static void Run(SepReader.ColAction action, string colValue = ColText, Func<SepReaderOptions, SepReaderOptions>? configure = null)
     {
         Func<SepReaderOptions, SepReaderOptions> defaultConfigure = static c => c;

--- a/src/Sep.Test/SepReaderColsTest.cs
+++ b/src/Sep.Test/SepReaderColsTest.cs
@@ -29,14 +29,15 @@ public class SepReaderColsTest
     }
 
     [TestMethod]
-    public void SepReaderColsTest_Parse()
+    public void SepReaderColsTest_ToStringsArray()
     {
-        Run(cols => CollectionAssert.AreEqual(_colValues, cols.Parse<int>().ToArray()));
-        Run(cols => CollectionAssert.AreEqual(_colValuesFloat, cols.Parse<float>().ToArray()));
-#if NET8_0_OR_GREATER
-        // string unfortunately did not implement ISpanParsable until .NET 8
-        Run(cols => CollectionAssert.AreEqual(_colTexts, cols.Parse<string>().ToArray()));
-#endif
+        Run(cols => CollectionAssert.AreEqual(_colTexts, cols.ToStringsArray()));
+    }
+
+    [TestMethod]
+    public void SepReaderColsTest_ToStrings()
+    {
+        Run(cols => CollectionAssert.AreEqual(_colTexts, cols.ToStrings().ToArray()));
     }
 
     [TestMethod]
@@ -44,9 +45,21 @@ public class SepReaderColsTest
     {
         Run(cols => CollectionAssert.AreEqual(_colValues, cols.ParseToArray<int>()));
         Run(cols => CollectionAssert.AreEqual(_colValuesFloat, cols.ParseToArray<float>()));
+        Run(cols => CollectionAssert.AreEqual(_colTexts, cols.ToStringsArray()));
 #if NET8_0_OR_GREATER
-        // string unfortunately did not implement ISpanParsable until .NET 8
+        // string unfortunately did not implement ISpanParsable until .NET 8 see ToStringsArray
         Run(cols => CollectionAssert.AreEqual(_colTexts, cols.ParseToArray<string>()));
+#endif
+    }
+
+    [TestMethod]
+    public void SepReaderColsTest_Parse()
+    {
+        Run(cols => CollectionAssert.AreEqual(_colValues, cols.Parse<int>().ToArray()));
+        Run(cols => CollectionAssert.AreEqual(_colValuesFloat, cols.Parse<float>().ToArray()));
+#if NET8_0_OR_GREATER
+        // string unfortunately did not implement ISpanParsable until .NET 8 see ToStrings
+        Run(cols => CollectionAssert.AreEqual(_colTexts, cols.Parse<string>().ToArray()));
 #endif
     }
 

--- a/src/Sep.Test/SepReaderColsTest.cs
+++ b/src/Sep.Test/SepReaderColsTest.cs
@@ -33,6 +33,21 @@ public class SepReaderColsTest
     {
         Run(cols => CollectionAssert.AreEqual(_colValues, cols.Parse<int>().ToArray()));
         Run(cols => CollectionAssert.AreEqual(_colValuesFloat, cols.Parse<float>().ToArray()));
+#if NET8_0_OR_GREATER
+        // string unfortunately did not implement ISpanParsable until .NET 8
+        Run(cols => CollectionAssert.AreEqual(_colTexts, cols.Parse<string>().ToArray()));
+#endif
+    }
+
+    [TestMethod]
+    public void SepReaderColsTest_ParseToArray()
+    {
+        Run(cols => CollectionAssert.AreEqual(_colValues, cols.ParseToArray<int>()));
+        Run(cols => CollectionAssert.AreEqual(_colValuesFloat, cols.ParseToArray<float>()));
+#if NET8_0_OR_GREATER
+        // string unfortunately did not implement ISpanParsable until .NET 8
+        Run(cols => CollectionAssert.AreEqual(_colTexts, cols.ParseToArray<string>()));
+#endif
     }
 
     [TestMethod]

--- a/src/Sep.Test/SepReaderColsTest.cs
+++ b/src/Sep.Test/SepReaderColsTest.cs
@@ -45,7 +45,6 @@ public class SepReaderColsTest
     {
         Run(cols => CollectionAssert.AreEqual(_colValues, cols.ParseToArray<int>()));
         Run(cols => CollectionAssert.AreEqual(_colValuesFloat, cols.ParseToArray<float>()));
-        Run(cols => CollectionAssert.AreEqual(_colTexts, cols.ToStringsArray()));
 #if NET8_0_OR_GREATER
         // string unfortunately did not implement ISpanParsable until .NET 8 see ToStringsArray
         Run(cols => CollectionAssert.AreEqual(_colTexts, cols.ParseToArray<string>()));

--- a/src/Sep.Test/SepReaderRowTest.cs
+++ b/src/Sep.Test/SepReaderRowTest.cs
@@ -198,6 +198,22 @@ public class SepReaderRowTest
         Assert.AreEqual("  1:[2..3] = ' ;;1.23456789;abcdefgh\t, ._'", _enumerator.Current.DebuggerDisplay);
     }
 
+    [TestMethod]
+    public void SepReaderRowTest_Row_DebugView()
+    {
+        var rowDebugView = new SepReader.Row.DebugView(_enumerator.Current);
+        var cols = rowDebugView.Cols;
+        Assert.AreEqual(_cols, cols.Length);
+        for (var colIndex = 0; colIndex < cols.Length; colIndex++)
+        {
+            var col = cols[colIndex];
+            Assert.AreEqual(colIndex, col.ColIndex);
+            Assert.AreEqual(_colNames[colIndex], col.ColName);
+            Assert.AreEqual(_colValues[colIndex], col.ColValue);
+            Assert.AreEqual($"{colIndex:D2}:'{_colNames[colIndex]}'", col.ColIndexName);
+        }
+    }
+
     static void AssertCols(ReadOnlySpan<string> expected, in SepReader.Cols cols)
     {
         Assert.AreEqual(expected.Length, cols.Length);

--- a/src/Sep.Test/SepReaderRowTest.cs
+++ b/src/Sep.Test/SepReaderRowTest.cs
@@ -193,9 +193,9 @@ public class SepReaderRowTest
     }
 
     [TestMethod]
-    public void SepReaderRowTest_Row_DebuggerDisplay()
+    public void SepReaderRowTest_Row_DebuggerDisplayPrefix()
     {
-        Assert.AreEqual("  1:[2..3] = ' ;;1.23456789;abcdefgh\t, ._'", _enumerator.Current.DebuggerDisplay);
+        Assert.AreEqual("  1:[2..3] = ", _enumerator.Current.DebuggerDisplayPrefix);
     }
 
     [TestMethod]

--- a/src/Sep.Test/SepReaderTest.cs
+++ b/src/Sep.Test/SepReaderTest.cs
@@ -480,6 +480,60 @@ public class SepReaderTest
         Assert.AreEqual(true, reader.MoveNext());
     }
 
+    [TestMethod]
+    public void SepReaderTest_DebuggerDisplay_FromText()
+    {
+        using var reader = Sep.Reader().FromText("A;B");
+        Assert.AreEqual("String Length=3", reader.DebuggerDisplay);
+    }
+
+    [TestMethod]
+    public void SepReaderTest_DebuggerDisplay_FromFile()
+    {
+        var filePath = Path.GetTempFileName();
+        File.WriteAllText(filePath, "A;B");
+        using (var reader = Sep.Reader().FromFile(filePath))
+        {
+            Assert.AreEqual($"File='{filePath}'", reader.DebuggerDisplay);
+        }
+        File.Delete(filePath);
+    }
+
+    [TestMethod]
+    public void SepReaderTest_DebuggerDisplay_FromBytes()
+    {
+        using var reader = Sep.Reader().From(Encoding.UTF8.GetBytes("A;B"));
+        Assert.AreEqual($"Bytes Length=3", reader.DebuggerDisplay);
+    }
+
+    [TestMethod]
+    public void SepReaderTest_DebuggerDisplay_FromNameStream()
+    {
+        var name = "TEST";
+        using var reader = Sep.Reader().From(name, n => (Stream)new MemoryStream(Encoding.UTF8.GetBytes("A;B")));
+        Assert.AreEqual($"Stream Name='{name}'", reader.DebuggerDisplay);
+    }
+    [TestMethod]
+    public void SepReaderTest_DebuggerDisplay_FromStream()
+    {
+        using var reader = Sep.Reader().From((Stream)new MemoryStream(Encoding.UTF8.GetBytes("A;B")));
+        Assert.AreEqual($"Stream='{typeof(MemoryStream)}'", reader.DebuggerDisplay);
+    }
+
+    [TestMethod]
+    public void SepReaderTest_DebuggerDisplay_FromNameTextReader()
+    {
+        var name = "TEST";
+        using var reader = Sep.Reader().From(name, n => (TextReader)new StringReader("A;B"));
+        Assert.AreEqual($"TextReader Name='{name}'", reader.DebuggerDisplay);
+    }
+    [TestMethod]
+    public void SepReaderTest_DebuggerDisplay_FromTextReader()
+    {
+        using var reader = Sep.Reader().From((TextReader)new StringReader("A;B"));
+        Assert.AreEqual($"TextReader='{typeof(StringReader)}'", reader.DebuggerDisplay);
+    }
+
     public class FakeLongMemoryStream : MemoryStream
     {
         readonly long _fakeLength;

--- a/src/Sep/SepReader.Col.cs
+++ b/src/Sep/SepReader.Col.cs
@@ -7,7 +7,7 @@ namespace nietras.SeparatedValues;
 
 public partial class SepReader
 {
-    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    [DebuggerDisplay("{DebuggerDisplay}")]
     public readonly ref struct Col
     {
         readonly SepReader _reader;

--- a/src/Sep/SepReader.Cols.cs
+++ b/src/Sep/SepReader.Cols.cs
@@ -26,7 +26,25 @@ public partial class SepReader
 
         public Col this[int index] => new(_reader, _colIndices[index]);
 
+        /// <summary>
+        /// Get all cols as strings in an array.
+        /// </summary>
+        /// <remarks>
+        /// Convenience method since <see cref="Parse{T}()" /> only works for
+        /// <see cref="string"/> in .NET 8+ where <see cref="string"/>  is <see
+        /// cref="ISpanParsable{TSelf}"/>.
+        /// </remarks>
+        /// <returns>Newly allocated array of each col as a string.</returns>
         public string[] ToStringsArray() => _reader.ToStringsArray(_colIndices);
+        /// <summary>
+        /// Get all cols as strings in a span.
+        /// </summary>
+        /// <remarks>
+        /// Convenience method since <see cref="Parse{T}()" /> only works for
+        /// <see cref="string"/> in .NET 8+ where <see cref="string"/>  is <see
+        /// cref="ISpanParsable{TSelf}"/>.
+        /// </remarks>
+        /// <returns>Span with each col as a string.</returns>
         public Span<string> ToStrings() => _reader.ToStrings(_colIndices);
 
         public T[] ParseToArray<T>() where T : ISpanParsable<T> =>

--- a/src/Sep/SepReader.Cols.cs
+++ b/src/Sep/SepReader.Cols.cs
@@ -27,7 +27,7 @@ public partial class SepReader
         public Col this[int index] => new(_reader, _colIndices[index]);
 
         /// <summary>
-        /// Get all cols as strings in an array.
+        /// Get all selected cols as strings in an array.
         /// </summary>
         /// <remarks>
         /// Convenience method since <see cref="Parse{T}()" /> only works for
@@ -37,7 +37,7 @@ public partial class SepReader
         /// <returns>Newly allocated array of each col as a string.</returns>
         public string[] ToStringsArray() => _reader.ToStringsArray(_colIndices);
         /// <summary>
-        /// Get all cols as strings in a span.
+        /// Get all selected cols as strings in a span.
         /// </summary>
         /// <remarks>
         /// Convenience method since <see cref="Parse{T}()" /> only works for

--- a/src/Sep/SepReader.Cols.cs
+++ b/src/Sep/SepReader.Cols.cs
@@ -26,6 +26,13 @@ public partial class SepReader
 
         public Col this[int index] => new(_reader, _colIndices[index]);
 
+        public T[] ParseToArray<T>() where T : ISpanParsable<T>
+        {
+            var values = new T[_colIndices.Length];
+            _reader.Parse<T>(_colIndices, values);
+            return values;
+        }
+
         public Span<T> Parse<T>() where T : ISpanParsable<T> =>
             _reader.Parse<T>(_colIndices);
 

--- a/src/Sep/SepReader.Cols.cs
+++ b/src/Sep/SepReader.Cols.cs
@@ -30,7 +30,7 @@ public partial class SepReader
         /// Get all selected cols as strings in an array.
         /// </summary>
         /// <remarks>
-        /// Convenience method since <see cref="Parse{T}()" /> only works for
+        /// Convenience method since <see cref="ParseToArray{T}()" /> only works for
         /// <see cref="string"/> in .NET 8+ where <see cref="string"/>  is <see
         /// cref="ISpanParsable{TSelf}"/>.
         /// </remarks>

--- a/src/Sep/SepReader.Row.cs
+++ b/src/Sep/SepReader.Row.cs
@@ -12,7 +12,7 @@ public partial class SepReader
     public delegate void RowAction(Row row);
     public delegate T RowFunc<T>(Row row);
 
-    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    [DebuggerDisplay("{DebuggerDisplayPrefix,nq}{Span}")]
     [DebuggerTypeProxy(typeof(DebugView))]
     public readonly ref struct Row
     {
@@ -126,7 +126,7 @@ public partial class SepReader
         //    throw new NotImplementedException();
         //}
 
-        internal string DebuggerDisplay => $"{RowIndex,3}:[{LineNumberFrom}..{LineNumberToExcl}] = '{Span}'";
+        internal string DebuggerDisplayPrefix => $"{RowIndex,3}:[{LineNumberFrom}..{LineNumberToExcl}] = ";
 
         internal class DebugView
         {

--- a/src/Sep/SepReader.Row.cs
+++ b/src/Sep/SepReader.Row.cs
@@ -132,26 +132,22 @@ public partial class SepReader
         {
             readonly SepReader _reader;
 
-            public DebugView(Row row)
-            {
-                _reader = row._reader;
-            }
+            internal DebugView(Row row) => _reader = row._reader;
 
             [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-            public ColDebugView[] Cols
+            internal ColDebugView[] Cols => GetCols();
+
+            ColDebugView[] GetCols()
             {
-                get
+                var row = _reader.Current;
+                var cols = new ColDebugView[_reader._colCount];
+                var maybeHeader = _reader.HasHeader ? _reader._header : null;
+                for (var colIndex = 0; colIndex < cols.Length; colIndex++)
                 {
-                    var row = _reader.Current;
-                    var cols = new ColDebugView[_reader._colCount];
-                    var maybeHeader = _reader.HasHeader ? _reader._header : null;
-                    for (var colIndex = 0; colIndex < cols.Length; colIndex++)
-                    {
-                        var colValue = row[colIndex].ToStringRaw();
-                        cols[colIndex] = new(colIndex, maybeHeader?.ColNames[colIndex], colValue);
-                    }
-                    return cols;
+                    var colValue = row[colIndex].ToStringRaw();
+                    cols[colIndex] = new(colIndex, maybeHeader?.ColNames[colIndex], colValue);
                 }
+                return cols;
             }
         }
 

--- a/src/Sep/SepReader.cs
+++ b/src/Sep/SepReader.cs
@@ -11,14 +11,19 @@ using static nietras.SeparatedValues.SepDefaults;
 
 namespace nietras.SeparatedValues;
 
+[DebuggerDisplay("{DebuggerDisplay,nq}")]
 public partial class SepReader : IDisposable
 {
+    internal readonly record struct Info(object Source, Func<Info, string> DebuggerDisplay);
+    internal string DebuggerDisplay => _info.DebuggerDisplay(_info);
+
     const string TraceCondition = "SEPREADERTRACE";
     const string AssertCondition = "SEPREADERASSERT";
 
     // To avoid `call     CORINFO_HELP_GETSHARED_NONGCSTATIC_BASE`,
     // promote cache to member here.
     readonly string[] _singleCharToString = SepStringCache.SingleCharToString;
+    readonly Info _info;
     readonly SepReaderOptions _options;
     readonly char _fastFloatDecimalSeparatorOrZero;
     char _separator;
@@ -64,8 +69,9 @@ public partial class SepReader : IDisposable
     int _cacheIndex = 0;
     readonly SepToString[] _colToStrings;
 
-    internal SepReader(SepReaderOptions options, TextReader reader)
+    internal SepReader(Info info, SepReaderOptions options, TextReader reader)
     {
+        _info = info;
         _options = options;
         _reader = reader;
         _cultureInfo = _options.CultureInfo;

--- a/src/Sep/SepReaderExtensions.cs
+++ b/src/Sep/SepReaderExtensions.cs
@@ -37,29 +37,53 @@ public static class SepReaderExtensions
 
     public static SepReader FromText(this SepReaderOptions options, string text)
     {
+        ArgumentNullException.ThrowIfNull(text);
         var reader = new StringReader(text);
-        return From(options, reader);
+        Func<SepReader.Info, string> display = static info => $"From string with Length {((string)info.Source).Length}";
+        return FromWithInfo(new(text, display), options, reader);
     }
 
     public static SepReader FromFile(this SepReaderOptions options, string filePath)
     {
         var reader = new StreamReader(filePath, s_streamReaderOptions);
-        return From(options, reader);
+        Func<SepReader.Info, string> display = static info => $"From File '{info.Source}'";
+        return FromWithInfo(new(filePath, display), options, reader);
     }
 
+    public static SepReader From(this SepReaderOptions options, string name, Func<string, Stream> nameToStream)
+    {
+        ArgumentNullException.ThrowIfNull(nameToStream);
+        var reader = new StreamReader(nameToStream(name));
+        Func<SepReader.Info, string> display = static info => $"From Stream with Name '{info.Source}'";
+        return FromWithInfo(new(name, display), options, reader);
+    }
     public static SepReader From(this SepReaderOptions options, Stream stream)
     {
         var reader = new StreamReader(stream);
-        return From(options, reader);
+        Func<SepReader.Info, string> display = static info => $"From Stream '{info.Source}'";
+        return FromWithInfo(new(stream, display), options, reader);
     }
 
+    public static SepReader From(this SepReaderOptions options, string name, Func<string, TextReader> nameToReader)
+    {
+        ArgumentNullException.ThrowIfNull(nameToReader);
+        var reader = nameToReader(name);
+        Func<SepReader.Info, string> display = static info => $"From TextReader with Name '{info.Source}'";
+        return FromWithInfo(new(name, display), options, reader);
+    }
     public static SepReader From(this SepReaderOptions options, TextReader reader)
+    {
+        Func<SepReader.Info, string> display = static info => $"From TextReader '{info.Source}'";
+        return FromWithInfo(new(reader, display), options, reader);
+    }
+
+    internal static SepReader FromWithInfo(SepReader.Info info, SepReaderOptions options, TextReader reader)
     {
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(reader);
         try
         {
-            return new SepReader(options, reader);
+            return new SepReader(info, options, reader);
         }
         catch (Exception)
         {

--- a/src/Sep/SepReaderExtensions.cs
+++ b/src/Sep/SepReaderExtensions.cs
@@ -39,28 +39,35 @@ public static class SepReaderExtensions
     {
         ArgumentNullException.ThrowIfNull(text);
         var reader = new StringReader(text);
-        Func<SepReader.Info, string> display = static info => $"From string with Length {((string)info.Source).Length}";
+        Func<SepReader.Info, string> display = static info => $"String Length={((string)info.Source).Length}";
         return FromWithInfo(new(text, display), options, reader);
     }
 
     public static SepReader FromFile(this SepReaderOptions options, string filePath)
     {
         var reader = new StreamReader(filePath, s_streamReaderOptions);
-        Func<SepReader.Info, string> display = static info => $"From File '{info.Source}'";
+        Func<SepReader.Info, string> display = static info => $"File='{info.Source}'";
         return FromWithInfo(new(filePath, display), options, reader);
+    }
+
+    public static SepReader From(this SepReaderOptions options, byte[] buffer)
+    {
+        var reader = new StreamReader(new MemoryStream(buffer));
+        Func<SepReader.Info, string> display = static info => $"Bytes Length={((byte[])info.Source).Length}";
+        return FromWithInfo(new(buffer, display), options, reader);
     }
 
     public static SepReader From(this SepReaderOptions options, string name, Func<string, Stream> nameToStream)
     {
         ArgumentNullException.ThrowIfNull(nameToStream);
         var reader = new StreamReader(nameToStream(name));
-        Func<SepReader.Info, string> display = static info => $"From Stream with Name '{info.Source}'";
+        Func<SepReader.Info, string> display = static info => $"Stream Name='{info.Source}'";
         return FromWithInfo(new(name, display), options, reader);
     }
     public static SepReader From(this SepReaderOptions options, Stream stream)
     {
         var reader = new StreamReader(stream);
-        Func<SepReader.Info, string> display = static info => $"From Stream '{info.Source}'";
+        Func<SepReader.Info, string> display = static info => $"Stream='{info.Source}'";
         return FromWithInfo(new(stream, display), options, reader);
     }
 
@@ -68,12 +75,12 @@ public static class SepReaderExtensions
     {
         ArgumentNullException.ThrowIfNull(nameToReader);
         var reader = nameToReader(name);
-        Func<SepReader.Info, string> display = static info => $"From TextReader with Name '{info.Source}'";
+        Func<SepReader.Info, string> display = static info => $"TextReader Name='{info.Source}'";
         return FromWithInfo(new(name, display), options, reader);
     }
     public static SepReader From(this SepReaderOptions options, TextReader reader)
     {
-        Func<SepReader.Info, string> display = static info => $"From TextReader '{info.Source}'";
+        Func<SepReader.Info, string> display = static info => $"TextReader='{info.Source}'";
         return FromWithInfo(new(reader, display), options, reader);
     }
 


### PR DESCRIPTION
 * Verify `Parse<string>` and similar works on .NET 8 where `string : ISpanParsable<string>`, but also introduce `ToStrings`/`ToStringsArray` for convenience
 * `SepReader` DebuggerDisplay will show source for reader via internal `SepReader.Info`
 * `SepReader.Row` adds `DebuggerTypeProxy` to show each col when expanding in debug view
 * Add `From(string name, Func<string, Stream> nameToStream)` and `From(string name, Func<string, TextReader> nameToReader)` overloads to support abstraction contexts