### PR TITLE
Add Cols range support also if col names are continuous

### DIFF
--- a/src/Sep.Test/SepReaderColsTest.cs
+++ b/src/Sep.Test/SepReaderColsTest.cs
@@ -44,6 +44,23 @@ public class SepReaderColsTest
     }
 
     [TestMethod]
+    public void SepReaderColsTest_Indexer_OutOfRange_Throws()
+    {
+        Run((cols, range) =>
+        {
+            try
+            {
+                var col = cols[cols.Length + 1];
+                Assert.Fail("Indexer should throw for out of range index.");
+            }
+            catch (IndexOutOfRangeException e)
+            {
+                Assert.IsNotNull(e);
+            }
+        });
+    }
+
+    [TestMethod]
     public void SepReaderColsTest_ToStringsArray()
     {
         Run((cols, range) => CollectionAssert.AreEqual(_colTexts[range], cols.ToStringsArray()));

--- a/src/Sep.Test/SepReaderColsTest.cs
+++ b/src/Sep.Test/SepReaderColsTest.cs
@@ -31,6 +31,19 @@ public class SepReaderColsTest
     }
 
     [TestMethod]
+    public void SepReaderColsTest_Indexer()
+    {
+        Run((cols, range) =>
+        {
+            var expectedTexts = _colTexts[range];
+            for (var i = 0; i < expectedTexts.Length; i++)
+            {
+                Assert.AreEqual(expectedTexts[i], cols[i].ToString());
+            }
+        });
+    }
+
+    [TestMethod]
     public void SepReaderColsTest_ToStringsArray()
     {
         Run((cols, range) => CollectionAssert.AreEqual(_colTexts[range], cols.ToStringsArray()));

--- a/src/Sep.Test/SepReaderRowTest.cs
+++ b/src/Sep.Test/SepReaderRowTest.cs
@@ -253,5 +253,9 @@ public class SepReaderRowTest
         {
             Assert.AreEqual(expected[i], cols[i].ToString(), i.ToString());
         }
+        CollectionAssert.AreEqual(expected.ToArray(), cols.ToStringsArray());
+#if NET8_0_OR_GREATER
+        CollectionAssert.AreEqual(expected.ToArray(), cols.ParseToArray<string>());
+#endif
     }
 }

--- a/src/Sep.Test/SepReaderRowTest.cs
+++ b/src/Sep.Test/SepReaderRowTest.cs
@@ -140,20 +140,52 @@ public class SepReaderRowTest
             SepReaderRowTest_Row_Indexer_Multiple(ref row);
         }
     }
+
+    [TestMethod]
+    public void SepReaderRowTest_Row_Indexer_Multiple_Range()
+    {
+        var row = _enumerator.Current;
+        SepReaderRowTest_Row_Indexer_Multiple_Range(ref row);
+    }
+
     static void SepReaderRowTest_Row_Indexer_Multiple(ref SepReader.Row row)
     {
-        var indices = new int[2] { 1, 2 };
-        var names = indices.Select(i => _colNames[i]).ToArray();
-        var expected = indices.Select(i => _colValues[i]).ToArray();
+        var indicesSet = new int[][]
+        {
+            new[]{ 0 },
+            new[]{ 0, 1 },
+            new[]{ 0, 2 },
+            new[]{ 1, 3 },
+            new[]{ 1, 2, 3 },
+        };
+        foreach (var indices in indicesSet)
+        {
+            var names = indices.Select(i => _colNames[i]).ToArray();
+            var expected = indices.Select(i => _colValues[i]).ToArray();
 
-        AssertCols(expected, row[1..3]);
-        AssertCols(expected, row[indices.AsSpan()]);
-        AssertCols(expected, row[(IReadOnlyList<int>)indices]);
-        AssertCols(expected, row[indices]);
+            AssertCols(_colValues[1..3], row[1..3]);
+            AssertCols(expected, row[indices.AsSpan()]);
+            AssertCols(expected, row[(IReadOnlyList<int>)indices]);
+            AssertCols(expected, row[indices]);
 
-        AssertCols(expected, row[names.AsSpan()]);
-        AssertCols(expected, row[(IReadOnlyList<string>)names]);
-        AssertCols(expected, row[names]);
+            AssertCols(expected, row[names.AsSpan()]);
+            AssertCols(expected, row[(IReadOnlyList<string>)names]);
+            AssertCols(expected, row[names]);
+        }
+    }
+
+    static void SepReaderRowTest_Row_Indexer_Multiple_Range(ref SepReader.Row row)
+    {
+        var ranges = new Range[]
+        {
+            0..0,
+            1..3,
+            0.._cols,
+        };
+        foreach (var range in ranges)
+        {
+            AssertCols(_colValues[range], row[range]);
+        }
     }
 
     [TestMethod]

--- a/src/Sep.Test/SepReaderRowTest.cs
+++ b/src/Sep.Test/SepReaderRowTest.cs
@@ -163,7 +163,6 @@ public class SepReaderRowTest
             var names = indices.Select(i => _colNames[i]).ToArray();
             var expected = indices.Select(i => _colValues[i]).ToArray();
 
-            AssertCols(_colValues[1..3], row[1..3]);
             AssertCols(expected, row[indices.AsSpan()]);
             AssertCols(expected, row[(IReadOnlyList<int>)indices]);
             AssertCols(expected, row[indices]);
@@ -179,6 +178,7 @@ public class SepReaderRowTest
         var ranges = new Range[]
         {
             0..0,
+            1..2,
             1..3,
             0.._cols,
         };

--- a/src/Sep/SepReader.Cols.cs
+++ b/src/Sep/SepReader.Cols.cs
@@ -100,15 +100,15 @@ public partial class SepReader
 
         bool IsIndices() => _colStartIfRange < 0;
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         int GetRangeIndex(int index)
         {
             Debug.Assert(_colStartIfRange >= 0);
-            if ((uint)index < (uint)_colIndices.Length)
+            if ((uint)index >= (uint)_colIndices.Length)
             {
-                return index + _colStartIfRange;
+                SepThrow.IndexOutOfRangeException();
             }
-            SepThrow.IndexOutOfRangeException();
-            return 0;
+            return index + _colStartIfRange;
         }
     }
 }


### PR DESCRIPTION
Avoids allocating an array from pool for col indices if col name is a range or if selection is a range from start.