### PR TITLE
Remove SepReader.Col.ToStringRaw from public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1258,7 +1258,6 @@ namespace nietras.SeparatedValues
             public T Parse<T>()
                 where T : System.ISpanParsable<T> { }
             public override string ToString() { }
-            public string ToStringRaw() { }
             public T? TryParse<T>()
                 where T :  struct, System.ISpanParsable<T> { }
             public bool TryParse<T>(out T value)

--- a/src/Sep.Test/SepReaderColTest.cs
+++ b/src/Sep.Test/SepReaderColTest.cs
@@ -40,7 +40,7 @@ public class SepReaderColTest
     }
 
     [TestMethod]
-    public void SepReaderColTest_ToStringRaw()
+    public void SepReaderColTest_ToStringDirect()
     {
         Run(col => Assert.AreEqual(ColText, col.ToStringDirect()));
         Run(col => Assert.AreSame(string.Empty, col.ToString()), "");

--- a/src/Sep.Test/SepReaderColTest.cs
+++ b/src/Sep.Test/SepReaderColTest.cs
@@ -42,7 +42,7 @@ public class SepReaderColTest
     [TestMethod]
     public void SepReaderColTest_ToStringRaw()
     {
-        Run(col => Assert.AreEqual(ColText, col.ToStringRaw()));
+        Run(col => Assert.AreEqual(ColText, col.ToStringDirect()));
         Run(col => Assert.AreSame(string.Empty, col.ToString()), "");
     }
 

--- a/src/Sep.Test/SepReaderColsTest.cs
+++ b/src/Sep.Test/SepReaderColsTest.cs
@@ -174,7 +174,7 @@ public class SepReaderColsTest
     [TestMethod]
     public void SepReaderColsTest_Select_ToStringRaw()
     {
-        Run((cols, range) => CollectionAssert.AreEqual(_colTexts[range], cols.Select(c => c.ToStringRaw()).ToArray()));
+        Run((cols, range) => CollectionAssert.AreEqual(_colTexts[range], cols.Select(c => c.ToStringDirect()).ToArray()));
     }
 
     static string ToString(SepReader.Col col) => col.ToString();

--- a/src/Sep.Test/SepReaderColsTest.cs
+++ b/src/Sep.Test/SepReaderColsTest.cs
@@ -172,7 +172,7 @@ public class SepReaderColsTest
     }
 
     [TestMethod]
-    public void SepReaderColsTest_Select_ToStringRaw()
+    public void SepReaderColsTest_Select_ToStringDirect()
     {
         Run((cols, range) => CollectionAssert.AreEqual(_colTexts[range], cols.Select(c => c.ToStringDirect()).ToArray()));
     }

--- a/src/Sep/CompatibilitySuppressions.xml
+++ b/src/Sep/CompatibilitySuppressions.xml
@@ -3,6 +3,13 @@
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:nietras.SeparatedValues.SepReader.Col.ToStringRaw</Target>
+    <Left>lib/net7.0/Sep.dll</Left>
+    <Right>lib/net7.0/Sep.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:nietras.SeparatedValues.SepReader.Cols.get_Length</Target>
     <Left>lib/net7.0/Sep.dll</Left>
     <Right>lib/net7.0/Sep.dll</Right>

--- a/src/Sep/SepReader.Col.cs
+++ b/src/Sep/SepReader.Col.cs
@@ -26,7 +26,7 @@ public partial class SepReader
 
         // Allow opt out of pooling and don't add yet another configuration option
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal string ToStringRaw() => _state.ToStringRaw(_colIndex);
+        internal string ToStringDirect() => _state.ToStringDirect(_colIndex);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public T Parse<T>() where T : ISpanParsable<T> => _state.Parse<T>(_colIndex);

--- a/src/Sep/SepReader.Col.cs
+++ b/src/Sep/SepReader.Col.cs
@@ -26,7 +26,7 @@ public partial class SepReader
 
         // Allow opt out of pooling and don't add yet another configuration option
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public string ToStringRaw() => _state.ToStringRaw(_colIndex);
+        internal string ToStringRaw() => _state.ToStringRaw(_colIndex);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public T Parse<T>() where T : ISpanParsable<T> => _state.Parse<T>(_colIndex);

--- a/src/Sep/SepReader.Row.cs
+++ b/src/Sep/SepReader.Row.cs
@@ -200,7 +200,7 @@ public partial class SepReader
                 var maybeHeader = _state._hasHeader ? _state._header : null;
                 for (var colIndex = 0; colIndex < cols.Length; colIndex++)
                 {
-                    var colValue = row[colIndex].ToStringRaw();
+                    var colValue = row[colIndex].ToStringDirect();
                     cols[colIndex] = new(colIndex, maybeHeader?.ColNames[colIndex], colValue);
                 }
                 return cols;

--- a/src/Sep/SepReader.cs
+++ b/src/Sep/SepReader.cs
@@ -113,7 +113,7 @@ public sealed partial class SepReader : SepReaderState
                 var colNameToIndex = new Dictionary<string, int>(_colCount);
                 for (var colIndex = 0; colIndex < _colCount; colIndex++)
                 {
-                    var colName = ToStringRaw(colIndex);
+                    var colName = ToStringDirect(colIndex);
                     colNameToIndex.Add(colName, colIndex);
                 }
                 var headerRow = new string(RowSpan());

--- a/src/Sep/SepReaderState.cs
+++ b/src/Sep/SepReaderState.cs
@@ -169,7 +169,7 @@ public class SepReaderState : IDisposable
         return _toString.ToString(span, index);
     }
 
-    internal string ToStringRaw(int index)
+    internal string ToStringDirect(int index)
     {
         var span = GetColSpan(index);
         var s = TryGetStaticallyCachedString(span);


### PR DESCRIPTION
With unescape "Raw" becomes confusing as users may think this means no unescaping while it's intend was to mean unpooled, it has therefore been made internal and renamed to `ToStringDirect`.