### PR TITLE
Add a Cursively comparison benchmark

### DIFF
--- a/src/Sep.ComparisonBenchmarks/BytesStatisticColumn.cs
+++ b/src/Sep.ComparisonBenchmarks/BytesStatisticColumn.cs
@@ -58,6 +58,12 @@ public class BytesStatisticColumn : IColumn
             if (statistics != null)
             {
                 var bytes = _getBytes(benchmarkCase.Parameters.Items);
+                if (benchmarkCase.Descriptor.WorkloadMethod.Name == "Cursively")
+                {
+                    // Cursively operates on the bytes, and input is all ASCII, so this gives it a
+                    // more appropriate result for the associated columns.
+                    bytes /= 2;
+                }
                 return _format(bytes, benchmarkCase, statistics);
             }
         }

--- a/src/Sep.ComparisonBenchmarks/FloatsReaderBench.cs
+++ b/src/Sep.ComparisonBenchmarks/FloatsReaderBench.cs
@@ -129,7 +129,6 @@ public class RowFloatsReaderBench : FloatsReaderBench
 #endif
     public void Cursively()
     {
-        // not immediately sure what this was supposed to be?
         CsvSyncInput.ForMemory(Bytes).WithDelimiter((byte)';').Process(CsvReaderVisitorBase.Null);
     }
 }
@@ -233,7 +232,6 @@ public class ColsFloatsReaderBench : FloatsReaderBench
 #endif
     public void Cursively()
     {
-        // not immediately sure what this was supposed to be?
         CsvSyncInput.ForMemory(Bytes).WithDelimiter((byte)';').Process(CsvReaderVisitorBase.Null);
     }
 }
@@ -247,14 +245,7 @@ public class FloatsFloatsReaderBench : FloatsReaderBench
     const int DefaultLineCount = 25_000;
 #endif
 
-    public FloatsFloatsReaderBench() : base("Floats", DefaultLineCount)
-    {
-        // my own testing code... delete if you find it irrelevant
-        if (Sep______() != Cursively())
-        {
-            throw new InvalidOperationException("Cursively is busted.");
-        }
-    }
+    public FloatsFloatsReaderBench() : base("Floats", DefaultLineCount) { }
 
     delegate string SpanToString(ReadOnlySpan<char> chars);
 
@@ -497,7 +488,7 @@ public class FloatsFloatsReaderBench : FloatsReaderBench
 
         public override void VisitPartialFieldContents(ReadOnlySpan<byte> chunk)
         {
-            throw new NotImplementedException("Haven't needed to use this one: no quoted fields, and the whole input is one big chunk.");
+            throw new NotSupportedException("We don't need this one for this specific benchmark: there are no quoted fields at all, and the whole input is one big chunk.");
         }
 
         public override void VisitEndOfField(ReadOnlySpan<byte> chunk)

--- a/src/Sep.ComparisonBenchmarks/Program.cs
+++ b/src/Sep.ComparisonBenchmarks/Program.cs
@@ -152,7 +152,8 @@ static long BytesFromReaderSpec(IReadOnlyList<ParameterInstance> parameters)
 static string GetVersions() =>
      $"Sep {GetFileVersion(typeof(nietras.SeparatedValues.SepReader).Assembly)}, " +
      $"Sylvan  {GetFileVersion(typeof(Sylvan.Data.Csv.CsvDataReader).Assembly)}, " +
-     $"CsvHelper {GetFileVersion(typeof(CsvHelper.CsvReader).Assembly)}";
+     $"CsvHelper {GetFileVersion(typeof(CsvHelper.CsvReader).Assembly)}, " +
+     $"Cursively {GetFileVersion(typeof(Cursively.CsvSyncInput).Assembly)}";
 
 static string GetFileVersion(Assembly assembly) =>
     FileVersionInfo.GetVersionInfo(assembly.Location).FileVersion!;

--- a/src/Sep.ComparisonBenchmarks/Sep.ComparisonBenchmarks.csproj
+++ b/src/Sep.ComparisonBenchmarks/Sep.ComparisonBenchmarks.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.12" />
     <PackageReference Include="csFastFloat" Version="4.1.0" />
     <PackageReference Include="CsvHelper" Version="30.0.1" />
+    <PackageReference Include="Cursively" Version="1.2.0" />
     <PackageReference Include="Sylvan.Common" Version="0.4.3" />
     <PackageReference Include="Sylvan.Data.Csv" Version="1.3.5" />
   </ItemGroup>


### PR DESCRIPTION
I wrote [Cursively](https://github.com/airbreather/Cursively) a few years ago when I was dealing with a file that was almost exclusively a bunch of numeric values, pretty much exactly like the "Floats" comparison benchmark.

There's basically no reason to use it instead of Sep now (at least in version 1.2.0, and I probably won't bother going further with it because Sep is just too good), but maybe you might think that the performance is still **close enough** to be worth adding to your benchmarks?

My benchmark run:

```

BenchmarkDotNet v0.13.12, EndeavourOS
AMD Ryzen 9 7950X, 1 CPU, 32 logical and 16 physical cores
.NET SDK 8.0.100
  [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
  Job-CYKMPX : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI

Runtime=.NET 8.0  Toolchain=net80  InvocationCount=Default  
IterationTime=350.0000 ms  MaxIterationCount=15  MinIterationCount=5  
WarmupCount=6  Reader=String  

```
| Method    | Scope  | Rows  | Mean      | Ratio | MB | MB/s   | ns/row | Allocated  | Alloc Ratio |
|---------- |------- |------ |----------:|------:|---:|-------:|-------:|-----------:|------------:|
| Sep______ | Floats | 25000 | 19.296 ms |  1.00 | 20 | 1050.6 |  771.8 |     8305 B |        1.00 |
| Sep_MT___ | Floats | 25000 |  3.984 ms |  0.21 | 20 | 5088.4 |  159.4 |   181614 B |       21.87 |
| Sylvan___ | Floats | 25000 | 53.505 ms |  2.77 | 20 |  378.9 | 2140.2 |    18970 B |        2.28 |
| ReadLine_ | Floats | 25000 | 65.653 ms |  3.40 | 20 |  308.8 | 2626.1 | 75257288 B |    9,061.68 |
| CsvHelper | Floats | 25000 | 95.554 ms |  4.95 | 20 |  212.2 | 3822.2 | 45002904 B |    5,418.77 |
| Cursively | Floats | 25000 | 20.283 ms |  1.05 | 10 |  499.7 |  811.3 |      308 B |        0.04 |
