### PR TITLE
Fix SepParser*s buffer overrun bug when column count is equal to internal capacity and new row after

### DIFF
--- a/README.md
+++ b/README.md
@@ -1481,7 +1481,7 @@ Ask questions on GitHub and this section will be expanded. :)
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Sep.Benchmarks")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Sep.ComparisonBenchmarks")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Sep.Test")]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v7.0", FrameworkDisplayName=".NET 7.0")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName=".NET 8.0")]
 namespace nietras.SeparatedValues
 {
     public readonly struct Sep : System.IEquatable<nietras.SeparatedValues.Sep>

--- a/README.md
+++ b/README.md
@@ -1481,7 +1481,7 @@ Ask questions on GitHub and this section will be expanded. :)
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Sep.Benchmarks")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Sep.ComparisonBenchmarks")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Sep.Test")]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName=".NET 8.0")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v7.0", FrameworkDisplayName=".NET 7.0")]
 namespace nietras.SeparatedValues
 {
     public readonly struct Sep : System.IEquatable<nietras.SeparatedValues.Sep>

--- a/src/Sep.Test/SepReaderTest.cs
+++ b/src/Sep.Test/SepReaderTest.cs
@@ -478,7 +478,7 @@ public class SepReaderTest
         // a `ArgumentOutOfRangeException` would occur on the slicing that
         // happens when these col infos are to be copied to beginning. This test
         // tries triggers that issue.
-        var colCounts = Enumerable.Range(1, SepReader.ColEndsInitialLength * 2);
+        var colCounts = Enumerable.Range(SepReader.ColEndsInitialLength - 1, 1);
         var charsLength = (int)BitOperations.RoundUpToPowerOf2(SepReader.CharsMinimumLength);
         foreach (var colCount in colCounts)
         {

--- a/src/Sep.Test/SepReaderTest.cs
+++ b/src/Sep.Test/SepReaderTest.cs
@@ -476,7 +476,8 @@ public class SepReaderTest
         // was present <= 0.4.3 as reported in issue #108
         // https://github.com/nietras/Sep/issues/108 where this was the case and
         // a `ArgumentOutOfRangeException` would occur on the slicing that
-        // happens when these col infos are to be copied to beginning.
+        // happens when these col infos are to be copied to beginning. This test
+        // tries triggers that issue.
         var colCounts = Enumerable.Range(1, SepReader.ColEndsInitialLength * 2);
         var charsLength = (int)BitOperations.RoundUpToPowerOf2(SepReader.CharsMinimumLength);
         foreach (var colCount in colCounts)

--- a/src/Sep.Test/SepReaderTest.cs
+++ b/src/Sep.Test/SepReaderTest.cs
@@ -477,7 +477,7 @@ public class SepReaderTest
         // https://github.com/nietras/Sep/issues/108 where this was the case and
         // an `ArgumentOutOfRangeException` would occur on the slicing that
         // happens when these col infos are to be copied to beginning. This test
-        // tries triggers that issue.
+        // triggers that issue.
         var colCounts = Enumerable.Range(SepReader.ColEndsInitialLength - 1, 1);
         var charsLength = (int)BitOperations.RoundUpToPowerOf2(SepReader.CharsMinimumLength);
         foreach (var colCount in colCounts)

--- a/src/Sep.Test/SepReaderTest.cs
+++ b/src/Sep.Test/SepReaderTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.IO;
 using System.Linq;
+using System.Numerics;
 using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -444,24 +445,50 @@ public class SepReaderTest
     [TestMethod]
     public void SepReaderTest_ColsInitialLength()
     {
-        var initialColCountCapacity = SepReader.ColEndsInitialLength - 1; // -1 since col ends is 1 longer due to having row start
-        var text = "A" + Environment.NewLine + new string(';', initialColCountCapacity - 1);
+        var colCount = SepReader.ColEndsInitialLength - 1; // -1 since col ends is 1 longer due to having row start
+        var text = "A" + Environment.NewLine + new string(';', colCount - 1);
         using var reader = Sep.Reader(o => o with { DisableColCountCheck = true }).FromText(text);
         Assert.IsTrue(reader.MoveNext());
         var row = reader.Current;
-        Assert.AreEqual(initialColCountCapacity, row.ColCount);
+        Assert.AreEqual(colCount, row.ColCount);
     }
 
     [TestMethod]
     public void SepReaderTest_ExceedingColsInitialLength_WorksByDoublingCapacity()
     {
-        var initialColCountCapacity = SepReader.ColEndsInitialLength;
-        var text = "A" + Environment.NewLine + new string(';', initialColCountCapacity - 1);
+        var colCount = SepReader.ColEndsInitialLength;
+        var text = "A" + Environment.NewLine + new string(';', colCount - 1);
         using var reader = Sep.Reader(o => o with { DisableColCountCheck = true }).FromText(text);
         Assert.IsTrue(reader.MoveNext());
         var row = reader.Current;
-        Assert.AreEqual(initialColCountCapacity, row.ColCount);
-        Assert.AreEqual(initialColCountCapacity * 2, reader._colEndsOrColInfos.Length);
+        Assert.AreEqual(colCount, row.ColCount);
+        Assert.AreEqual(colCount * 2, reader._colEndsOrColInfos.Length);
+    }
+
+    [TestMethod]
+    public void SepReaderTest_ColInfosLength_ParsingRowColCounts_ArgumentOutOfRangeException_Issue_108()
+    {
+        // At any time during parsing there may be an incomplete row e.g. a
+        // parsing row, when then new rows are about to be parsed e.g. in
+        // ParseNewRows(). The col ends/infos for that row need to be copied to
+        // beginning before new rows are found. At any time these col infos
+        // should never exceed the end of the array of col infos. However, a bug
+        // was present <= 0.4.3 as reported in issue #108
+        // https://github.com/nietras/Sep/issues/108 where this was the case and
+        // a `ArgumentOutOfRangeException` would occur on the slicing that
+        // happens when these col infos are to be copied to beginning.
+        var colCounts = Enumerable.Range(1, SepReader.ColEndsInitialLength * 2);
+        var charsLength = (int)BitOperations.RoundUpToPowerOf2(SepReader.CharsMinimumLength);
+        foreach (var colCount in colCounts)
+        {
+            var text = new string('A', Math.Max(1, charsLength - colCount + 1))
+                + new string(';', colCount - 1) + Environment.NewLine
+                + new string(';', colCount * 2);
+            using var reader = Sep
+                .Reader(o => o with { HasHeader = false, DisableColCountCheck = true })
+                .FromText(text);
+            while (reader.MoveNext()) { }
+        }
     }
 
 #if !SEPREADERTRACE // Causes OOMs in Debug due to tracing

--- a/src/Sep.Test/SepReaderTest.cs
+++ b/src/Sep.Test/SepReaderTest.cs
@@ -475,7 +475,7 @@ public class SepReaderTest
         // should never exceed the end of the array of col infos. However, a bug
         // was present <= 0.4.3 as reported in issue #108
         // https://github.com/nietras/Sep/issues/108 where this was the case and
-        // a `ArgumentOutOfRangeException` would occur on the slicing that
+        // an `ArgumentOutOfRangeException` would occur on the slicing that
         // happens when these col infos are to be copied to beginning. This test
         // tries triggers that issue.
         var colCounts = Enumerable.Range(SepReader.ColEndsInitialLength - 1, 1);

--- a/src/Sep.Test/SepReaderTest.cs
+++ b/src/Sep.Test/SepReaderTest.cs
@@ -466,7 +466,7 @@ public class SepReaderTest
     }
 
     [TestMethod]
-    public void SepReaderTest_ColInfosLength_ParsingRowColCounts_ArgumentOutOfRangeException_Issue_108()
+    public void SepReaderTest_ColInfosLength_ArgumentOutOfRangeException_Issue_108()
     {
         // At any time during parsing there may be an incomplete row e.g. a
         // parsing row, when then new rows are about to be parsed e.g. in

--- a/src/Sep/Internals/SepParserAvx2PackCmpOrMoveMaskTzcnt.cs
+++ b/src/Sep/Internals/SepParserAvx2PackCmpOrMoveMaskTzcnt.cs
@@ -81,7 +81,9 @@ sealed class SepParserAvx2PackCmpOrMoveMaskTzcnt : ISepParser
         ref var colInfosRefOrigin = ref As<int, TColInfo>(ref MemoryMarshal.GetArrayDataReference(colInfos));
         ref var colInfosRef = ref Add(ref colInfosRefOrigin, s._parsingRowColEndsOrInfosStartIndex);
         ref var colInfosRefCurrent = ref Add(ref colInfosRefOrigin, s._parsingRowColCount + s._parsingRowColEndsOrInfosStartIndex);
-        ref var colInfosRefStop = ref Add(ref colInfosRefOrigin, colInfosLength - VecUI8.Count);
+        ref var colInfosRefEnd = ref Add(ref colInfosRefOrigin, colInfosLength);
+        var colInfosStopLength = colInfosLength - VecUI8.Count - SepReaderState.ColEndsOrInfosExtraEndCount;
+        ref var colInfosRefStop = ref Add(ref colInfosRefOrigin, colInfosStopLength);
 
         charsIndex -= VecUI8.Count;
     LOOPSTEP:
@@ -89,7 +91,7 @@ sealed class SepParserAvx2PackCmpOrMoveMaskTzcnt : ISepParser
     LOOPNOSTEP:
         if (charsIndex < charsEnd &&
             // If current is greater than or equal than "stop", then there is no
-            // longer guaranteed space enough for next VecUI8.Count.
+            // longer guaranteed space enough for next VecUI8.Count + next row start.
             !IsAddressLessThan(ref colInfosRefStop, ref colInfosRefCurrent))
         {
             ref var charsRef = ref Add(ref charsOriginRef, (uint)charsIndex);
@@ -159,6 +161,7 @@ sealed class SepParserAvx2PackCmpOrMoveMaskTzcnt : ISepParser
             ++s._parsedRowsCount;
             // Next row start (one before)
             colInfosRefCurrent = ref Add(ref colInfosRefCurrent, 1);
+            A.Assert(IsAddressLessThan(ref colInfosRefCurrent, ref colInfosRefEnd));
             colInfosRefCurrent = TColInfoMethods.Create(charsIndex - 1, 0);
             // Update for next row
             colInfosRef = ref colInfosRefCurrent;

--- a/src/Sep/Internals/SepParserAvx512PackCmpOrMoveMaskTzcnt.cs
+++ b/src/Sep/Internals/SepParserAvx512PackCmpOrMoveMaskTzcnt.cs
@@ -85,7 +85,9 @@ sealed class SepParserAvx512PackCmpOrMoveMaskTzcnt : ISepParser
         ref var colInfosRefOrigin = ref As<int, TColInfo>(ref MemoryMarshal.GetArrayDataReference(colInfos));
         ref var colInfosRef = ref Add(ref colInfosRefOrigin, s._parsingRowColEndsOrInfosStartIndex);
         ref var colInfosRefCurrent = ref Add(ref colInfosRefOrigin, s._parsingRowColCount + s._parsingRowColEndsOrInfosStartIndex);
-        ref var colInfosRefStop = ref Add(ref colInfosRefOrigin, colInfosLength - VecUI8.Count);
+        ref var colInfosRefEnd = ref Add(ref colInfosRefOrigin, colInfosLength);
+        var colInfosStopLength = colInfosLength - VecUI8.Count - SepReaderState.ColEndsOrInfosExtraEndCount;
+        ref var colInfosRefStop = ref Add(ref colInfosRefOrigin, colInfosStopLength);
 
         charsIndex -= VecUI8.Count;
     LOOPSTEP:
@@ -93,7 +95,7 @@ sealed class SepParserAvx512PackCmpOrMoveMaskTzcnt : ISepParser
     LOOPNOSTEP:
         if (charsIndex < charsEnd &&
             // If current is greater than or equal than "stop", then there is no
-            // longer guaranteed space enough for next VecUI8.Count.
+            // longer guaranteed space enough for next VecUI8.Count + next row start.
             !IsAddressLessThan(ref colInfosRefStop, ref colInfosRefCurrent))
         {
             ref var charsRef = ref Add(ref charsOriginRef, (uint)charsIndex);
@@ -164,6 +166,7 @@ sealed class SepParserAvx512PackCmpOrMoveMaskTzcnt : ISepParser
             ++s._parsedRowsCount;
             // Next row start (one before)
             colInfosRefCurrent = ref Add(ref colInfosRefCurrent, 1);
+            A.Assert(IsAddressLessThan(ref colInfosRefCurrent, ref colInfosRefEnd));
             colInfosRefCurrent = TColInfoMethods.Create(charsIndex - 1, 0);
             // Update for next row
             colInfosRef = ref colInfosRefCurrent;

--- a/src/Sep/Internals/SepParserIndexOfAny.cs
+++ b/src/Sep/Internals/SepParserIndexOfAny.cs
@@ -18,7 +18,7 @@ sealed class SepParserIndexOfAny : ISepParser
         _specialChars = new[] { sep.Separator, CarriageReturn, LineFeed, Quote };
     }
 
-    public int PaddingLength => 0;
+    public int PaddingLength => 4;
     public int QuoteCount => (int)_quoteCount;
 
     [SkipLocalsInit]
@@ -71,7 +71,8 @@ sealed class SepParserIndexOfAny : ISepParser
 
         var span = chars.AsSpan(0, charsEnd);
         var specialCharsSpan = _specialChars.AsSpan();
-        while ((uint)charsIndex < (uint)charsEnd)
+        while ((uint)charsIndex < (uint)charsEnd &&
+               !IsAddressLessThan(ref colInfosRefStop, ref colInfosRefCurrent))
         {
             // https://github.com/dotnet/runtime/blob/942ce9af6e4858b74cc3a1429e9a64065ffb207a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs#L1926-L2045
             var relativeIndex = span.Slice(charsIndex).IndexOfAny(specialCharsSpan);
@@ -109,12 +110,6 @@ sealed class SepParserIndexOfAny : ISepParser
                     {
                         break;
                     }
-                }
-                // If current is greater than or equal than "stop", then break.
-                // There is no longer guaranteed space enough for next.
-                if (IsAddressLessThan(ref colInfosRefStop, ref colInfosRefCurrent))
-                {
-                    break;
                 }
             }
             else

--- a/src/Sep/Internals/SepParserIndexOfAny.cs
+++ b/src/Sep/Internals/SepParserIndexOfAny.cs
@@ -65,7 +65,9 @@ sealed class SepParserIndexOfAny : ISepParser
         ref var colInfosRefOrigin = ref As<int, TColInfo>(ref MemoryMarshal.GetArrayDataReference(colInfos));
         ref var colInfosRef = ref Add(ref colInfosRefOrigin, s._parsingRowColEndsOrInfosStartIndex);
         ref var colInfosRefCurrent = ref Add(ref colInfosRefOrigin, s._parsingRowColCount + s._parsingRowColEndsOrInfosStartIndex);
-        ref var colInfosRefStop = ref Add(ref colInfosRefOrigin, colInfosLength - 3);
+        ref var colInfosRefEnd = ref Add(ref colInfosRefOrigin, colInfosLength);
+        var colInfosStopLength = colInfosLength - 3 - SepReaderState.ColEndsOrInfosExtraEndCount;
+        ref var colInfosRefStop = ref Add(ref colInfosRefOrigin, colInfosStopLength);
 
         var span = chars.AsSpan(0, charsEnd);
         var specialCharsSpan = _specialChars.AsSpan();
@@ -96,6 +98,7 @@ sealed class SepParserIndexOfAny : ISepParser
                     ++s._parsedRowsCount;
                     // Next row start (one before)
                     colInfosRefCurrent = ref Add(ref colInfosRefCurrent, 1);
+                    A.Assert(IsAddressLessThan(ref colInfosRefCurrent, ref colInfosRefEnd));
                     colInfosRefCurrent = TColInfoMethods.Create(charsIndex - 1, 0);
                     // Update for next row
                     colInfosRef = ref colInfosRefCurrent;

--- a/src/Sep/Internals/SepParserVector128NrwCmpExtMsbTzcnt.cs
+++ b/src/Sep/Internals/SepParserVector128NrwCmpExtMsbTzcnt.cs
@@ -82,7 +82,9 @@ sealed class SepParserVector128NrwCmpExtMsbTzcnt : ISepParser
         ref var colInfosRefOrigin = ref As<int, TColInfo>(ref MemoryMarshal.GetArrayDataReference(colInfos));
         ref var colInfosRef = ref Add(ref colInfosRefOrigin, s._parsingRowColEndsOrInfosStartIndex);
         ref var colInfosRefCurrent = ref Add(ref colInfosRefOrigin, s._parsingRowColCount + s._parsingRowColEndsOrInfosStartIndex);
-        ref var colInfosRefStop = ref Add(ref colInfosRefOrigin, colInfosLength - VecUI8.Count);
+        ref var colInfosRefEnd = ref Add(ref colInfosRefOrigin, colInfosLength);
+        var colInfosStopLength = colInfosLength - VecUI8.Count - SepReaderState.ColEndsOrInfosExtraEndCount;
+        ref var colInfosRefStop = ref Add(ref colInfosRefOrigin, colInfosStopLength);
 
         charsIndex -= VecUI8.Count;
     LOOPSTEP:
@@ -90,7 +92,7 @@ sealed class SepParserVector128NrwCmpExtMsbTzcnt : ISepParser
     LOOPNOSTEP:
         if (charsIndex < charsEnd &&
             // If current is greater than or equal than "stop", then there is no
-            // longer guaranteed space enough for next VecUI8.Count.
+            // longer guaranteed space enough for next VecUI8.Count + next row start.
             !IsAddressLessThan(ref colInfosRefStop, ref colInfosRefCurrent))
         {
             ref var charsRef = ref Add(ref charsOriginRef, (uint)charsIndex);
@@ -160,6 +162,7 @@ sealed class SepParserVector128NrwCmpExtMsbTzcnt : ISepParser
             ++s._parsedRowsCount;
             // Next row start (one before)
             colInfosRefCurrent = ref Add(ref colInfosRefCurrent, 1);
+            A.Assert(IsAddressLessThan(ref colInfosRefCurrent, ref colInfosRefEnd));
             colInfosRefCurrent = TColInfoMethods.Create(charsIndex - 1, 0);
             // Update for next row
             colInfosRef = ref colInfosRefCurrent;

--- a/src/Sep/Internals/SepParserVector256NrwCmpExtMsbTzcnt.cs
+++ b/src/Sep/Internals/SepParserVector256NrwCmpExtMsbTzcnt.cs
@@ -81,7 +81,9 @@ sealed class SepParserVector256NrwCmpExtMsbTzcnt : ISepParser
         ref var colInfosRefOrigin = ref As<int, TColInfo>(ref MemoryMarshal.GetArrayDataReference(colInfos));
         ref var colInfosRef = ref Add(ref colInfosRefOrigin, s._parsingRowColEndsOrInfosStartIndex);
         ref var colInfosRefCurrent = ref Add(ref colInfosRefOrigin, s._parsingRowColCount + s._parsingRowColEndsOrInfosStartIndex);
-        ref var colInfosRefStop = ref Add(ref colInfosRefOrigin, colInfosLength - VecUI8.Count);
+        ref var colInfosRefEnd = ref Add(ref colInfosRefOrigin, colInfosLength);
+        var colInfosStopLength = colInfosLength - VecUI8.Count - SepReaderState.ColEndsOrInfosExtraEndCount;
+        ref var colInfosRefStop = ref Add(ref colInfosRefOrigin, colInfosStopLength);
 
         charsIndex -= VecUI8.Count;
     LOOPSTEP:
@@ -89,7 +91,7 @@ sealed class SepParserVector256NrwCmpExtMsbTzcnt : ISepParser
     LOOPNOSTEP:
         if (charsIndex < charsEnd &&
             // If current is greater than or equal than "stop", then there is no
-            // longer guaranteed space enough for next VecUI8.Count.
+            // longer guaranteed space enough for next VecUI8.Count + next row start.
             !IsAddressLessThan(ref colInfosRefStop, ref colInfosRefCurrent))
         {
             ref var charsRef = ref Add(ref charsOriginRef, (uint)charsIndex);
@@ -159,6 +161,7 @@ sealed class SepParserVector256NrwCmpExtMsbTzcnt : ISepParser
             ++s._parsedRowsCount;
             // Next row start (one before)
             colInfosRefCurrent = ref Add(ref colInfosRefCurrent, 1);
+            A.Assert(IsAddressLessThan(ref colInfosRefCurrent, ref colInfosRefEnd));
             colInfosRefCurrent = TColInfoMethods.Create(charsIndex - 1, 0);
             // Update for next row
             colInfosRef = ref colInfosRefCurrent;

--- a/src/Sep/Internals/SepParserVector512NrwCmpExtMsbTzcnt.cs
+++ b/src/Sep/Internals/SepParserVector512NrwCmpExtMsbTzcnt.cs
@@ -83,7 +83,9 @@ sealed class SepParserVector512NrwCmpExtMsbTzcnt : ISepParser
         ref var colInfosRefOrigin = ref As<int, TColInfo>(ref MemoryMarshal.GetArrayDataReference(colInfos));
         ref var colInfosRef = ref Add(ref colInfosRefOrigin, s._parsingRowColEndsOrInfosStartIndex);
         ref var colInfosRefCurrent = ref Add(ref colInfosRefOrigin, s._parsingRowColCount + s._parsingRowColEndsOrInfosStartIndex);
-        ref var colInfosRefStop = ref Add(ref colInfosRefOrigin, colInfosLength - VecUI8.Count);
+        ref var colInfosRefEnd = ref Add(ref colInfosRefOrigin, colInfosLength);
+        var colInfosStopLength = colInfosLength - VecUI8.Count - SepReaderState.ColEndsOrInfosExtraEndCount;
+        ref var colInfosRefStop = ref Add(ref colInfosRefOrigin, colInfosStopLength);
 
         charsIndex -= VecUI8.Count;
     LOOPSTEP:
@@ -91,7 +93,7 @@ sealed class SepParserVector512NrwCmpExtMsbTzcnt : ISepParser
     LOOPNOSTEP:
         if (charsIndex < charsEnd &&
             // If current is greater than or equal than "stop", then there is no
-            // longer guaranteed space enough for next VecUI8.Count.
+            // longer guaranteed space enough for next VecUI8.Count + next row start.
             !IsAddressLessThan(ref colInfosRefStop, ref colInfosRefCurrent))
         {
             ref var charsRef = ref Add(ref charsOriginRef, (uint)charsIndex);
@@ -161,6 +163,7 @@ sealed class SepParserVector512NrwCmpExtMsbTzcnt : ISepParser
             ++s._parsedRowsCount;
             // Next row start (one before)
             colInfosRefCurrent = ref Add(ref colInfosRefCurrent, 1);
+            A.Assert(IsAddressLessThan(ref colInfosRefCurrent, ref colInfosRefEnd));
             colInfosRefCurrent = TColInfoMethods.Create(charsIndex - 1, 0);
             // Update for next row
             colInfosRef = ref colInfosRefCurrent;

--- a/src/Sep/Internals/SepParserVector64NrwCmpExtMsbTzcnt.cs
+++ b/src/Sep/Internals/SepParserVector64NrwCmpExtMsbTzcnt.cs
@@ -81,7 +81,9 @@ sealed class SepParserVector64NrwCmpExtMsbTzcnt : ISepParser
         ref var colInfosRefOrigin = ref As<int, TColInfo>(ref MemoryMarshal.GetArrayDataReference(colInfos));
         ref var colInfosRef = ref Add(ref colInfosRefOrigin, s._parsingRowColEndsOrInfosStartIndex);
         ref var colInfosRefCurrent = ref Add(ref colInfosRefOrigin, s._parsingRowColCount + s._parsingRowColEndsOrInfosStartIndex);
-        ref var colInfosRefStop = ref Add(ref colInfosRefOrigin, colInfosLength - VecUI8.Count);
+        ref var colInfosRefEnd = ref Add(ref colInfosRefOrigin, colInfosLength);
+        var colInfosStopLength = colInfosLength - VecUI8.Count - SepReaderState.ColEndsOrInfosExtraEndCount;
+        ref var colInfosRefStop = ref Add(ref colInfosRefOrigin, colInfosStopLength);
 
         charsIndex -= VecUI8.Count;
     LOOPSTEP:
@@ -89,7 +91,7 @@ sealed class SepParserVector64NrwCmpExtMsbTzcnt : ISepParser
     LOOPNOSTEP:
         if (charsIndex < charsEnd &&
             // If current is greater than or equal than "stop", then there is no
-            // longer guaranteed space enough for next VecUI8.Count.
+            // longer guaranteed space enough for next VecUI8.Count + next row start.
             !IsAddressLessThan(ref colInfosRefStop, ref colInfosRefCurrent))
         {
             ref var charsRef = ref Add(ref charsOriginRef, (uint)charsIndex);
@@ -159,6 +161,7 @@ sealed class SepParserVector64NrwCmpExtMsbTzcnt : ISepParser
             ++s._parsedRowsCount;
             // Next row start (one before)
             colInfosRefCurrent = ref Add(ref colInfosRefCurrent, 1);
+            A.Assert(IsAddressLessThan(ref colInfosRefCurrent, ref colInfosRefEnd));
             colInfosRefCurrent = TColInfoMethods.Create(charsIndex - 1, 0);
             // Update for next row
             colInfosRef = ref colInfosRefCurrent;

--- a/src/Sep/SepReader.cs
+++ b/src/Sep/SepReader.cs
@@ -191,6 +191,8 @@ public sealed partial class SepReader : SepReaderState
         _currentRowColCount = -1;
         _currentRowColEndsOrInfosOffset = 0;
 
+        CheckPoint($"{nameof(ParseNewRows)} BEGINNING");
+
         // Move data to start
         if (_parsingRowCharsStartIndex > 0)
         {
@@ -201,7 +203,7 @@ public sealed partial class SepReader : SepReaderState
             A.Assert(_charsParseStart >= offset);
             _charsParseStart -= offset;
 
-            //A.Assert((_parsingRowColEndsOrInfosStartIndex + _parsingRowColCount + 1) * GetIntegersPerColInfo() <= _colEndsOrColInfos.Length);
+            A.Assert((_parsingRowColEndsOrInfosStartIndex + _parsingRowColCount + 1) * GetIntegersPerColInfo() <= _colEndsOrColInfos.Length);
 
             // Adjust found current row col infos, note includes col count since +1
             if (_colUnquoteUnescape == 0)
@@ -447,7 +449,7 @@ public sealed partial class SepReader : SepReaderState
     }
 
     [ExcludeFromCodeCoverage]
-    [Conditional(TraceCondition), Conditional("SEPREADERCHECKPOINT")]
+    [Conditional(TraceCondition), Conditional(AssertCondition)]
     void CheckPoint(string name, [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)
     {
         TraceState(name, filePath, lineNumber);
@@ -491,12 +493,13 @@ public sealed partial class SepReader : SepReaderState
         A.Assert(0 <= _charsDataEnd && _charsDataEnd <= _chars.Length, $"{name}", filePath, lineNumber);
         A.Assert(_charsDataStart <= _charsDataEnd, $"{name}", filePath, lineNumber);
         A.Assert(_charsDataStart <= _parsingRowCharsStartIndex && _parsingRowCharsStartIndex <= _charsDataEnd, $"{name}", filePath, lineNumber);
+        A.Assert((_parsingRowColEndsOrInfosStartIndex + _parsingRowColCount + 1) * GetIntegersPerColInfo() <= _colEndsOrColInfos.Length);
 
         if (_colUnquoteUnescape == 0)
         {
             var colEnds = GetColsEntireSpanAs<int>();
             A.Assert(colEnds.Length > 0, $"{name}", filePath, lineNumber);
-            A.Assert(0 <= _currentRowColCount && _currentRowColCount <= colEnds.Length, $"{name}", filePath, lineNumber);
+            A.Assert(-1 <= _currentRowColCount && _currentRowColCount <= colEnds.Length, $"{name}", filePath, lineNumber);
             for (var i = 0; i < _currentRowColCount; i++)
             {
                 var colEnd = colEnds[i];
@@ -509,7 +512,7 @@ public sealed partial class SepReader : SepReaderState
         {
             var colInfos = GetColsEntireSpanAs<SepColInfo>();
             A.Assert(colInfos.Length > 0, $"{name}", filePath, lineNumber);
-            A.Assert(0 <= _currentRowColCount && _currentRowColCount <= colInfos.Length, $"{name}", filePath, lineNumber);
+            A.Assert(-1 <= _currentRowColCount && _currentRowColCount <= colInfos.Length, $"{name}", filePath, lineNumber);
             for (var i = 0; i < _currentRowColCount; i++)
             {
                 var (colEnd, _) = colInfos[i];

--- a/src/Sep/SepReader.cs
+++ b/src/Sep/SepReader.cs
@@ -316,8 +316,7 @@ public sealed partial class SepReader : SepReaderState
 
         if (_parser != null && _charsParseStart < _charsDataEnd)
         {
-            // + 1 - must be room for one more col always
-            if ((_parsingRowColEndsOrInfosStartIndex + _parsingRowColCount + 1) >= (GetColInfosLength() - _parser.PaddingLength - ColEndsOrInfosExtraEndCount))
+            if ((_parsingRowColEndsOrInfosStartIndex + _parsingRowColCount + ColEndsOrInfosExtraEndCount) >= (GetColInfosLength() - _parser.PaddingLength))
             {
                 DoubleColInfosCapacityCopyState();
             }
@@ -326,8 +325,7 @@ public sealed partial class SepReader : SepReaderState
         {
             if (nothingLeftToRead)
             {
-                // + 1 - must be room for one more col always
-                if ((_parsingRowColEndsOrInfosStartIndex + _parsingRowColCount + 1) >= (GetColInfosLength() - ColEndsOrInfosExtraEndCount))
+                if ((_parsingRowColEndsOrInfosStartIndex + _parsingRowColCount + ColEndsOrInfosExtraEndCount) >= (GetColInfosLength() - ColEndsOrInfosExtraEndCount))
                 {
                     DoubleColInfosCapacityCopyState();
                 }

--- a/src/Sep/SepReader.cs
+++ b/src/Sep/SepReader.cs
@@ -317,7 +317,7 @@ public sealed partial class SepReader : SepReaderState
         if (_parser != null && _charsParseStart < _charsDataEnd)
         {
             // + 1 - must be room for one more col always
-            if ((_parsingRowColEndsOrInfosStartIndex + _parsingRowColCount + 1) >= (GetColInfosLength() - _parser.PaddingLength))
+            if ((_parsingRowColEndsOrInfosStartIndex + _parsingRowColCount + 1) >= (GetColInfosLength() - _parser.PaddingLength - ColEndsOrInfosExtraEndCount))
             {
                 DoubleColInfosCapacityCopyState();
             }
@@ -327,7 +327,7 @@ public sealed partial class SepReader : SepReaderState
             if (nothingLeftToRead)
             {
                 // + 1 - must be room for one more col always
-                if ((_parsingRowColEndsOrInfosStartIndex + _parsingRowColCount + 1) >= GetColInfosLength())
+                if ((_parsingRowColEndsOrInfosStartIndex + _parsingRowColCount + 1) >= (GetColInfosLength() - ColEndsOrInfosExtraEndCount))
                 {
                     DoubleColInfosCapacityCopyState();
                 }

--- a/src/Sep/SepReader.cs
+++ b/src/Sep/SepReader.cs
@@ -325,7 +325,7 @@ public sealed partial class SepReader : SepReaderState
         {
             if (nothingLeftToRead)
             {
-                if ((_parsingRowColEndsOrInfosStartIndex + _parsingRowColCount + ColEndsOrInfosExtraEndCount) >= (GetColInfosLength() - ColEndsOrInfosExtraEndCount))
+                if ((_parsingRowColEndsOrInfosStartIndex + _parsingRowColCount + ColEndsOrInfosExtraEndCount) >= GetColInfosLength())
                 {
                     DoubleColInfosCapacityCopyState();
                 }

--- a/src/Sep/SepReader.cs
+++ b/src/Sep/SepReader.cs
@@ -201,6 +201,8 @@ public sealed partial class SepReader : SepReaderState
             A.Assert(_charsParseStart >= offset);
             _charsParseStart -= offset;
 
+            //A.Assert((_parsingRowColEndsOrInfosStartIndex + _parsingRowColCount + 1) * GetIntegersPerColInfo() <= _colEndsOrColInfos.Length);
+
             // Adjust found current row col infos, note includes col count since +1
             if (_colUnquoteUnescape == 0)
             {
@@ -226,8 +228,9 @@ public sealed partial class SepReader : SepReaderState
             var intsPerColInfo = GetIntegersPerColInfo();
             var colInfosSpan = _colEndsOrColInfos.AsSpan();
             var length = (_parsingRowColCount + 1) * intsPerColInfo;
-            colInfosSpan.Slice(_parsingRowColEndsOrInfosStartIndex * intsPerColInfo, length)
-                .CopyTo(colInfosSpan.Slice(0, length));
+            var source = colInfosSpan.Slice(_parsingRowColEndsOrInfosStartIndex * intsPerColInfo, length);
+            var destination = colInfosSpan.Slice(0, length);
+            source.CopyTo(destination);
             _parsingRowColEndsOrInfosStartIndex = 0;
         }
 

--- a/src/Sep/SepReaderState.cs
+++ b/src/Sep/SepReaderState.cs
@@ -41,6 +41,8 @@ public class SepReaderState : IDisposable
 #else
     internal const int ColEndsInitialLength = 8 * 1024;
 #endif
+    // 1 for first col end and since pre-increment, 1 for next row start
+    internal const int ColEndsOrInfosExtraEndCount = 2;
     // Multiple rows of format
     // [0] = Previous row/col end e.g. one before row/first col start
     // [1..ColCount] = Col ends/infos e.g. [1] = first col end/info


### PR DESCRIPTION
Fixes #108 
Bug likely present since 0.4.0 when parsing multiple rows at a time was introduced.