### PR TITLE
Fix SepWriter.Row[ReadOnlySpan<int> indices] bug, add params ReadOnlySpan support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1896,7 +1896,7 @@ namespace nietras.SeparatedValues
             public nietras.SeparatedValues.SepWriter.Col this[int colIndex] { get; }
             public void Format<T>(System.Collections.Generic.IReadOnlyList<T> values)
                 where T : System.ISpanFormattable { }
-            public void Format<T>(System.ReadOnlySpan<T> values)
+            public void Format<T>([System.Runtime.CompilerServices.ParamCollection] [System.Runtime.CompilerServices.ScopedRef] System.ReadOnlySpan<T> values)
                 where T : System.ISpanFormattable { }
             public void Format<T>(System.Span<T> values)
                 where T : System.ISpanFormattable { }
@@ -1904,7 +1904,7 @@ namespace nietras.SeparatedValues
                 where T : System.ISpanFormattable { }
             public void Format<T>(System.ReadOnlySpan<T> values, nietras.SeparatedValues.SepWriter.ColAction<T> format) { }
             public void Set(System.Collections.Generic.IReadOnlyList<string> values) { }
-            public void Set(System.ReadOnlySpan<string> values) { }
+            public void Set([System.Runtime.CompilerServices.ParamCollection] [System.Runtime.CompilerServices.ScopedRef] System.ReadOnlySpan<string> values) { }
             public void Set(string[] values) { }
             public void Set(nietras.SeparatedValues.SepReader.Cols cols) { }
         }

--- a/README.md
+++ b/README.md
@@ -1638,7 +1638,7 @@ Ask questions on GitHub and this section will be expanded. :)
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Sep.ComparisonBenchmarks")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Sep.Test")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Sep.XyzTest")]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName=".NET 8.0")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v9.0", FrameworkDisplayName=".NET 9.0")]
 namespace nietras.SeparatedValues
 {
     public readonly struct Sep : System.IEquatable<nietras.SeparatedValues.Sep>
@@ -1774,7 +1774,7 @@ namespace nietras.SeparatedValues
         public static nietras.SeparatedValues.SepReaderHeader Empty { get; }
         public int IndexOf(string colName) { }
         public int[] IndicesOf(System.Collections.Generic.IReadOnlyList<string> colNames) { }
-        public int[] IndicesOf([System.Runtime.CompilerServices.ScopedRef] System.ReadOnlySpan<string> colNames) { }
+        public int[] IndicesOf([System.Runtime.CompilerServices.ParamCollection] [System.Runtime.CompilerServices.ScopedRef] System.ReadOnlySpan<string> colNames) { }
         public int[] IndicesOf(params string[] colNames) { }
         public void IndicesOf(System.ReadOnlySpan<string> colNames, System.Span<int> colIndices) { }
         public System.Collections.Generic.IReadOnlyList<string> NamesStartingWith(string prefix, System.StringComparison comparison = 4) { }

--- a/README.md
+++ b/README.md
@@ -1931,7 +1931,7 @@ namespace nietras.SeparatedValues
     public sealed class SepWriterHeader
     {
         public void Add(System.Collections.Generic.IReadOnlyList<string> colNames) { }
-        public void Add(System.ReadOnlySpan<string> colNames) { }
+        public void Add([System.Runtime.CompilerServices.ParamCollection] [System.Runtime.CompilerServices.ScopedRef] System.ReadOnlySpan<string> colNames) { }
         public void Add(string colName) { }
         public void Add(string[] colNames) { }
         public void Write() { }

--- a/README.md
+++ b/README.md
@@ -1774,7 +1774,7 @@ namespace nietras.SeparatedValues
         public static nietras.SeparatedValues.SepReaderHeader Empty { get; }
         public int IndexOf(string colName) { }
         public int[] IndicesOf(System.Collections.Generic.IReadOnlyList<string> colNames) { }
-        public int[] IndicesOf(System.ReadOnlySpan<string> colNames) { }
+        public int[] IndicesOf([System.Runtime.CompilerServices.ScopedRef] System.ReadOnlySpan<string> colNames) { }
         public int[] IndicesOf(params string[] colNames) { }
         public void IndicesOf(System.ReadOnlySpan<string> colNames, System.Span<int> colIndices) { }
         public System.Collections.Generic.IReadOnlyList<string> NamesStartingWith(string prefix, System.StringComparison comparison = 4) { }

--- a/src/Sep.Test/SepReaderHeaderTest.cs
+++ b/src/Sep.Test/SepReaderHeaderTest.cs
@@ -41,7 +41,7 @@ public class SepReaderHeaderTest
 
         Assert.AreEqual(1, header.IndexOf("B"));
         AreEqual([2, 0, 1], header.IndicesOf("C", "A", "B"));
-        AreEqual([1, 2, 0], header.IndicesOf(new[] { "B", "C", "A" }.AsSpan()));
+        AreEqual([1, 2, 0], header.IndicesOf(new[] { "B", "C", "A" }));
         AreEqual([0, 2], header.IndicesOf((ReadOnlySpan<string>)["A", "C"]));
         AreEqual([2, 0], header.IndicesOf((IReadOnlyList<string>)["C", "A"]));
 

--- a/src/Sep.Test/SepReaderRowTest.cs
+++ b/src/Sep.Test/SepReaderRowTest.cs
@@ -182,7 +182,7 @@ public class SepReaderRowTest
             AssertCols(expected, row[names]);
         }
 
-        // params ReadOnlySpan<int>
+        // params ReadOnlySpan<>
         AssertCols([_colValues[2], _colValues[3]], row[2, 3]);
         AssertCols([_colValues[2], _colValues[3]], row[_colNames[2], _colNames[3]]);
     }

--- a/src/Sep.Test/SepReaderRowTest.cs
+++ b/src/Sep.Test/SepReaderRowTest.cs
@@ -184,6 +184,7 @@ public class SepReaderRowTest
 
         // params ReadOnlySpan<int>
         AssertCols([_colValues[2], _colValues[3]], row[2, 3]);
+        AssertCols([_colValues[2], _colValues[3]], row[_colNames[2], _colNames[3]]);
     }
 
     static void SepReaderRowTest_Row_Indexer_Multiple_Range(ref SepReader.Row row)

--- a/src/Sep.Test/SepReaderRowTest.cs
+++ b/src/Sep.Test/SepReaderRowTest.cs
@@ -181,6 +181,9 @@ public class SepReaderRowTest
             AssertCols(expected, row[(IReadOnlyList<string>)names]);
             AssertCols(expected, row[names]);
         }
+
+        // params ReadOnlySpan<int>
+        AssertCols([_colValues[2], _colValues[3]], row[2, 3]);
     }
 
     static void SepReaderRowTest_Row_Indexer_Multiple_Range(ref SepReader.Row row)

--- a/src/Sep.Test/SepWriterHeaderTest.cs
+++ b/src/Sep.Test/SepWriterHeaderTest.cs
@@ -89,6 +89,20 @@ public class SepWriterHeaderTest
     }
 
     [TestMethod]
+    public void SepWriterHeaderTest_Add_ReadOnlySpan_Params_Rows_0()
+    {
+        using var writer = CreateWriter();
+        writer.Header.Add("A", "B", "C");
+        var expected =
+@"A;B;C
+";
+        // Header written on Dispose
+        writer.Dispose();
+
+        Assert.AreEqual(expected, writer.ToString());
+    }
+
+    [TestMethod]
     public void SepWriterHeaderTest_Add_String_Rows_0()
     {
         using var writer = CreateWriter();

--- a/src/Sep.Test/SepWriterRowTest.cs
+++ b/src/Sep.Test/SepWriterRowTest.cs
@@ -29,12 +29,30 @@ public class SepWriterRowTest
         var colNames = new string[] { "A", "B" };
         var colValues0 = new string[] { "1", "2" };
         var colIndices = new int[] { 1, 0 };
-        var colValues1 = new string[] { "11", "22" };
+        var colValues1 = new string[] { "22", "11" };
         Run(row =>
             {
                 row[colNames.AsSpan()].Set(colValues0.AsSpan());
                 row[colIndices.AsSpan()].Set(colValues1.AsSpan());
             }, $"A;B{NL}11;22{NL}");
+    }
+    [TestMethod]
+    public void SepWriterRowTest_Indexer_ColIndices_After_ColNames_Params_Set()
+    {
+        Run(row =>
+        {
+            row["A", "B"].Set("1", "2");
+            row[1, 0].Set("22", "11");
+        }, $"A;B{NL}11;22{NL}");
+    }
+    [TestMethod]
+    public void SepWriterRowTest_Indexer_ColIndices_After_ColNames_Params_Format()
+    {
+        Run(row =>
+        {
+            row["A", "B"].Set("1", "2");
+            row[1, 0].Format(22, 11);
+        }, $"A;B{NL}11;22{NL}");
     }
 
     [TestMethod]
@@ -57,6 +75,17 @@ public class SepWriterRowTest
         Run(row => row["A"].Set("1"), $"A{NL}1{NL}");
         Run(row => { row["A"].Set("1"); row["B"].Set("2"); },
             $"A;B{NL}1;2{NL}");
+    }
+
+    [TestMethod]
+    public void SepWriterRowTest_Indexer_ColNames_Params_ReadOnlySpan_Set()
+    {
+        Run(row => row["A", "B"].Set("1", "2"), $"A;B{NL}1;2{NL}");
+    }
+    [TestMethod]
+    public void SepWriterRowTest_Indexer_ColNames_Params_ReadOnlySpan_Format()
+    {
+        Run(row => row["A", "B"].Format(1, 2), $"A;B{NL}1;2{NL}");
     }
 
     [TestMethod]

--- a/src/Sep.XyzTest/ReadMeTest.cs
+++ b/src/Sep.XyzTest/ReadMeTest.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 #if NET9_0
@@ -12,8 +11,8 @@ using PublicApiGenerator;
 #endif
 #pragma warning disable CA2007 // Consider calling ConfigureAwait on the awaited task
 
-// Only parallize on class level to avoid multiple writes to README file
-[assembly: Parallelize(Workers = 0, Scope = ExecutionScope.ClassLevel)]
+// Only parallelize on class level to avoid multiple writes to README file
+[assembly: Parallelize(Workers = 1, Scope = ExecutionScope.ClassLevel)]
 
 namespace nietras.SeparatedValues.XyzTest;
 
@@ -384,8 +383,10 @@ public partial class ReadMeTest
         }
 
         var newReadme = string.Join(Environment.NewLine, readmeLines) + Environment.NewLine;
-        File.WriteAllText(readmeFilePath, newReadme, Encoding.UTF8);
-
+#if NET9_0
+        // Only write to file on latest version to avoid multiple accesses
+        File.WriteAllText(readmeFilePath, newReadme, System.Text.Encoding.UTF8);
+#endif
         static string LastDirectoryName(string d) =>
             d.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar).Last();
 
@@ -438,7 +439,10 @@ public partial class ReadMeTest
             sourceStartLineOffset: 0, "}", sourceEndLineOffset: 0, sourceWhitespaceToRemove: 4);
 
         var newReadme = string.Join(Environment.NewLine, readmeLines) + Environment.NewLine;
-        File.WriteAllText(readmeFilePath, newReadme, Encoding.UTF8);
+#if NET9_0
+        // Only write to file on latest version to avoid multiple accesses
+        File.WriteAllText(readmeFilePath, newReadme, System.Text.Encoding.UTF8);
+#endif
     }
 
     // Only update public API in README for latest .NET version to keep consistent
@@ -454,7 +458,7 @@ public partial class ReadMeTest
             "## Public API Reference", "```csharp", 1, "```", 0);
 
         var newReadme = string.Join(Environment.NewLine, readmeLines) + Environment.NewLine;
-        File.WriteAllText(readmeFilePath, newReadme, Encoding.UTF8);
+        File.WriteAllText(readmeFilePath, newReadme, System.Text.Encoding.UTF8);
     }
 #endif
 

--- a/src/Sep.XyzTest/ReadMeTest.cs
+++ b/src/Sep.XyzTest/ReadMeTest.cs
@@ -7,7 +7,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-#if NET8_0
+#if NET9_0
 using PublicApiGenerator;
 #endif
 #pragma warning disable CA2007 // Consider calling ConfigureAwait on the awaited task
@@ -441,8 +441,8 @@ public partial class ReadMeTest
         File.WriteAllText(readmeFilePath, newReadme, Encoding.UTF8);
     }
 
-    // Only update public API in README for .NET 8.0 to keep consistent
-#if NET8_0
+    // Only update public API in README for latest .NET version to keep consistent
+#if NET9_0
     [TestMethod]
     public void ReadMeTest_PublicApi()
     {

--- a/src/Sep/SepReader.Row.cs
+++ b/src/Sep/SepReader.Row.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace nietras.SeparatedValues;
@@ -66,7 +67,7 @@ public partial class SepReader
             }
         }
 
-        public Cols this[ReadOnlySpan<int> indices] => new(_state, indices);
+        public Cols this[[UnscopedRef] params ReadOnlySpan<int> indices] => new(_state, indices);
 
         public Cols this[IReadOnlyList<int> indices]
         {

--- a/src/Sep/SepReader.Row.cs
+++ b/src/Sep/SepReader.Row.cs
@@ -88,7 +88,7 @@ public partial class SepReader
         // ReadOnlySpan<> and IReadOnlyList<>
         public Cols this[int[] indices] => new(_state, indices);
 
-        public Cols this[ReadOnlySpan<string> colNames]
+        public Cols this[params ReadOnlySpan<string> colNames]
         {
             get
             {

--- a/src/Sep/SepReaderHeader.cs
+++ b/src/Sep/SepReaderHeader.cs
@@ -53,7 +53,7 @@ public sealed class SepReaderHeader
 
     public int[] IndicesOf(params string[] colNames) => IndicesOf(colNames.AsSpan());
 
-    public int[] IndicesOf(ReadOnlySpan<string> colNames)
+    public int[] IndicesOf(params ReadOnlySpan<string> colNames)
     {
         var colIndices = new int[colNames.Length];
         IndicesOf(colNames, colIndices);

--- a/src/Sep/SepWriter.Cols.cs
+++ b/src/Sep/SepWriter.Cols.cs
@@ -45,7 +45,7 @@ public partial class SepWriter
         // ReadOnlySpan<> and IReadOnlyList<>
         public void Set(string[] values) => Set(values.AsSpan());
 
-        public void Set(ReadOnlySpan<string> values)
+        public void Set(params ReadOnlySpan<string> values)
         {
             SepCheck.CountOrLengthSameAsCols(_cols.Length, nameof(values), values.Length);
             for (var i = 0; i < values.Length; i++)
@@ -71,7 +71,7 @@ public partial class SepWriter
         public void Format<T>(Span<T> values) where T : ISpanFormattable =>
             Format((ReadOnlySpan<T>)values);
 
-        public void Format<T>(ReadOnlySpan<T> values) where T : ISpanFormattable
+        public void Format<T>(params ReadOnlySpan<T> values) where T : ISpanFormattable
         {
             SepCheck.CountOrLengthSameAsCols(_cols.Length, nameof(values), values.Length);
             for (var i = 0; i < values.Length; i++)

--- a/src/Sep/SepWriter.Row.cs
+++ b/src/Sep/SepWriter.Row.cs
@@ -17,20 +17,20 @@ public partial class SepWriter
 
         public Col this[string colName] => new(_writer!.GetOrAddCol(colName));
 
-        public Cols this[ReadOnlySpan<int> indices]
+        public Cols this[params ReadOnlySpan<int> indices]
         {
             get
             {
                 var cols = _writer!._arrayPool.RentUniqueArrayAsSpan<ColImpl>(indices.Length);
                 for (var i = 0; i < indices.Length; i++)
                 {
-                    cols[i] = _writer!.GetOrAddCol(i);
+                    cols[i] = _writer!.GetOrAddCol(indices[i]);
                 }
                 return new Cols(cols);
             }
         }
 
-        public Cols this[ReadOnlySpan<string> colNames]
+        public Cols this[params ReadOnlySpan<string> colNames]
         {
             get
             {

--- a/src/Sep/SepWriterHeader.cs
+++ b/src/Sep/SepWriterHeader.cs
@@ -25,7 +25,7 @@ public sealed class SepWriterHeader
         foreach (var colName in colNames) { Add(colName); }
     }
 
-    public void Add(ReadOnlySpan<string> colNames)
+    public void Add(params ReadOnlySpan<string> colNames)
     {
         foreach (var colName in colNames) { Add(colName); }
     }


### PR DESCRIPTION
Fix a subtle but nasty bug in SepWriter where selecting col indices for row[[2, 3]] would not actually use those indices, but index [0, 1] instead, for example.