### PR TITLE
SepReader implement IEnumerable<>, IEnumerator<> (net9.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1815,7 +1815,7 @@ namespace nietras.SeparatedValues
         public static char Separator { get; }
     }
     [System.Diagnostics.DebuggerDisplay("{DebuggerDisplay,nq}")]
-    public sealed class SepReader : nietras.SeparatedValues.SepReaderState
+    public sealed class SepReader : nietras.SeparatedValues.SepReaderState, System.Collections.Generic.IEnumerable<nietras.SeparatedValues.SepReader.Row>, System.Collections.Generic.IEnumerator<nietras.SeparatedValues.SepReader.Row>, System.Collections.IEnumerable, System.Collections.IEnumerator, System.IDisposable
     {
         public nietras.SeparatedValues.SepReader.Row Current { get; }
         public bool HasHeader { get; }

--- a/src/Sep/SepReader.cs
+++ b/src/Sep/SepReader.cs
@@ -13,6 +13,10 @@ namespace nietras.SeparatedValues;
 
 [DebuggerDisplay("{DebuggerDisplay,nq}")]
 public sealed partial class SepReader : SepReaderState
+#if NET9_0_OR_GREATER
+    , IEnumerable<SepReader.Row>
+    , IEnumerator<SepReader.Row>
+#endif
 {
     internal readonly record struct Info(object Source, Func<Info, string> DebuggerDisplay);
     internal string DebuggerDisplay => _info.DebuggerDisplay(_info);
@@ -164,6 +168,13 @@ public sealed partial class SepReader : SepReaderState
     }
 
     public SepReader GetEnumerator() => this;
+#if NET9_0_OR_GREATER
+    IEnumerator<Row> IEnumerable<Row>.GetEnumerator() => this;
+    // Legacy not supported
+    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw new NotSupportedException();
+    object System.Collections.IEnumerator.Current => throw new NotSupportedException();
+    void System.Collections.IEnumerator.Reset() => throw new NotSupportedException();
+#endif
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool MoveNext()


### PR DESCRIPTION
With .NET 9 and C# 13 it is now possible to have SepReader implement IEnumerable<T> since this has `where T : allows ref struct` and many interfaces have been updated to support this. 