### PR TITLE
SepWriter.Col: Replace StringBuilder with ArrayPool array and DefaultInterpolatedStringHandler

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -35,7 +35,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            7.0.x
             8.0.x
       - name: Setup .NET (global.json)
         uses: actions/setup-dotnet@v4
@@ -78,7 +77,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        configuration: [Debug, Release]
 
     runs-on: ${{ matrix.os }}
 
@@ -88,7 +86,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            7.0.x
             8.0.x
       - name: Setup .NET (global.json)
         uses: actions/setup-dotnet@v4
@@ -96,8 +93,6 @@ jobs:
           global-json-file: global.json
       - name: Restore dependencies
         run: dotnet restore
-      - name: Build
-        run: dotnet build -c ${{ matrix.configuration }} --no-restore
       - name: Test Parsers
         shell: pwsh
         run: ./test-parsers.ps1
@@ -116,7 +111,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            7.0.x
             8.0.x
       - name: Setup .NET (global.json)
         uses: actions/setup-dotnet@v4

--- a/README.md
+++ b/README.md
@@ -2104,8 +2104,12 @@ namespace nietras.SeparatedValues
             public void Set(System.IFormatProvider? provider, [System.Runtime.CompilerServices.InterpolatedStringHandlerArgument(new string?[]?[] {
                     "",
                     "provider"})] ref nietras.SeparatedValues.SepWriter.Col.FormatInterpolatedStringHandler handler) { }
+            [System.Obsolete(("Types with embedded references are not supported in this version of your compiler" +
+                "."), true)]
+            [System.Runtime.CompilerServices.CompilerFeatureRequired("RefStructs")]
             [System.Runtime.CompilerServices.InterpolatedStringHandler]
-            public readonly struct FormatInterpolatedStringHandler
+            [System.Runtime.CompilerServices.IsByRefLike]
+            public struct FormatInterpolatedStringHandler
             {
                 public FormatInterpolatedStringHandler(int literalLength, int formattedCount, nietras.SeparatedValues.SepWriter.Col col) { }
                 public FormatInterpolatedStringHandler(int literalLength, int formattedCount, nietras.SeparatedValues.SepWriter.Col col, System.IFormatProvider? provider) { }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,7 +10,8 @@
     <Copyright>Copyright © nietras A/S 2023</Copyright>
     <NeutralLanguage>en</NeutralLanguage>
 
-    <TargetFrameworks>net9.0;net8.0;net7.0</TargetFrameworks>
+    <!--<TargetFrameworks>net9.0;net8.0;net7.0</TargetFrameworks>-->
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
 
     <LangVersion>13.0</LangVersion>

--- a/src/Sep.Benchmarks/Program.cs
+++ b/src/Sep.Benchmarks/Program.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;
@@ -22,16 +23,16 @@ if (args.Length > 0)
 {
     var config = (Debugger.IsAttached ? new DebugInProcessConfig() : DefaultConfig.Instance)
         .WithSummaryStyle(SummaryStyle.Default.WithMaxParameterColumnWidth(200))
-        .AddColumn(MBPerSecFromCharsLength())
+        //.AddColumn(MBPerSecFromCharsLength())
         ;
-    //BenchmarkSwitcher.FromAssembly(Assembly.GetExecutingAssembly()).Run(args, config);
+    BenchmarkSwitcher.FromAssembly(Assembly.GetExecutingAssembly()).Run(args, config);
     //BenchmarkRunner.Run(typeof(SepReaderBench), config, args);
     //BenchmarkRunner.Run(typeof(SepWriterBench), config, args);
     //BenchmarkRunner.Run(typeof(SepReaderWriterBench), config, args);
     //BenchmarkRunner.Run(typeof(SepEndToEndBench), config, args);
     //BenchmarkRunner.Run(typeof(SepHashBench), config, args);
     //BenchmarkRunner.Run(typeof(SepParseSeparatorsMaskBench), config, args);
-    BenchmarkRunner.Run(typeof(SepParserBench), config, args);
+    //BenchmarkRunner.Run(typeof(SepParserBench), config, args);
     //BenchmarkRunner.Run(typeof(StopwatchBench), config, args);
 }
 else

--- a/src/Sep.Benchmarks/Program.cs
+++ b/src/Sep.Benchmarks/Program.cs
@@ -47,8 +47,10 @@ else
     }
 }
 
+#pragma warning disable CS8321 // Local function is declared but never used
 static IColumn MBPerSecFromCharsLength() => new BytesStatisticColumn("MB/s",
     BytesFromCharsLength, BytesStatisticColumn.FormatMBPerSec);
+#pragma warning restore CS8321 // Local function is declared but never used
 
 static long BytesFromCharsLength(IReadOnlyList<ParameterInstance> parameters)
 {

--- a/src/Sep.Benchmarks/SepWriterBench.cs
+++ b/src/Sep.Benchmarks/SepWriterBench.cs
@@ -11,7 +11,7 @@ public class SepWriterBench
     [IterationSetup]
     public void Setup()
     {
-        _writer = Sep.Writer().ToText(256 * 1024 * 1024);
+        _writer = Sep.Writer(o => o with { WriteHeader = false }).ToText(256 * 1024 * 1024);
     }
 
     [IterationCleanup]
@@ -35,5 +35,15 @@ public class SepWriterBench
         writeRow["B"].Set("bbbbbbbbbbbbbbbbbbbbbb");
         writeRow["C"].Set("cccccccccccccccccccccccc");
         writeRow["D"].Set("ddddddddddddddddddddddddddddddd");
+    }
+
+    [Benchmark]
+    public void SetByColIndex()
+    {
+        using var writeRow = _writer!.NewRow();
+        writeRow[0].Set("aaaaaaaaaaaaaaaaaaa");
+        writeRow[1].Set("bbbbbbbbbbbbbbbbbbbbbb");
+        writeRow[2].Set("cccccccccccccccccccccccc");
+        writeRow[3].Set("ddddddddddddddddddddddddddddddd");
     }
 }

--- a/src/Sep.Test/Internals/InterpolatedStringHandlerTest.cs
+++ b/src/Sep.Test/Internals/InterpolatedStringHandlerTest.cs
@@ -7,59 +7,27 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace nietras.SeparatedValues.Test.Internals;
 
-public static class DefaultInterpolatedStringHandlerAccessor
-{
-#if NET8_0_OR_GREATER
-    public struct Class
-    {
-        static void StaticPrivateMethod() { }
-        static int StaticPrivateField;
-        public Class(int i) { PrivateField = i; }
-        void PrivateMethod() { }
-        int PrivateField;
-        int PrivateProperty { get => PrivateField; }
-    }
-
-
-    public static void GetSetPrivateField(Class c)
-    {
-        ref int f = ref GetSetPrivateField(ref c);
-        f = 43;
-
-        [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "PrivateField")]
-        extern static ref int GetSetPrivateField(ref Class c);
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_pos")]
-    static extern ref int Position(ref this DefaultInterpolatedStringHandler handler);
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_arrayToReturnToPool")]
-    static extern ref char[]? ArrayToReturnToPool(ref this DefaultInterpolatedStringHandler handler);
-
-    public static string Test()
-    {
-        var c = new Class(42);
-        GetSetPrivateField(c);
-
-        var buffer = new char[16];
-        var handler = new DefaultInterpolatedStringHandler(literalLength: 10, formattedCount: 2, provider: null, buffer);
-        ref var position = ref handler.Position();
-        position = 2;
-        handler.AppendFormatted(42);
-        return handler.ToStringAndClear();
-    }
-#endif
-}
-
 [TestClass]
 public class InterpolatedStringHandlerTest
 {
 #if NET8_0_OR_GREATER
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_pos")]
+    static extern ref int Position(ref DefaultInterpolatedStringHandler handler);
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_arrayToReturnToPool")]
+    static extern ref char[]? ArrayToReturnToPool(ref DefaultInterpolatedStringHandler handler);
+
     [TestMethod]
     public void InterpolatedStringHandlerTest_DefaultInterpolatedStringHandler_Accessor()
     {
-        DefaultInterpolatedStringHandlerAccessor.Test();
+        var buffer = new char[16];
+        var handler = new DefaultInterpolatedStringHandler(literalLength: 10, formattedCount: 2, provider: null, buffer);
+        ref var position = ref Position(ref handler);
+        position = 2;
+        handler.AppendFormatted(42);
+        var text = handler.ToStringAndClear();
+        Assert.IsNotNull(text);
     }
 #endif
 

--- a/src/Sep.Test/Internals/InterpolatedStringHandlerTest.cs
+++ b/src/Sep.Test/Internals/InterpolatedStringHandlerTest.cs
@@ -7,9 +7,62 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace nietras.SeparatedValues.Test.Internals;
 
+public static class DefaultInterpolatedStringHandlerAccessor
+{
+#if NET8_0_OR_GREATER
+    public struct Class
+    {
+        static void StaticPrivateMethod() { }
+        static int StaticPrivateField;
+        public Class(int i) { PrivateField = i; }
+        void PrivateMethod() { }
+        int PrivateField;
+        int PrivateProperty { get => PrivateField; }
+    }
+
+
+    public static void GetSetPrivateField(Class c)
+    {
+        ref int f = ref GetSetPrivateField(ref c);
+        f = 43;
+
+        [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "PrivateField")]
+        extern static ref int GetSetPrivateField(ref Class c);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_pos")]
+    static extern ref int Position(ref this DefaultInterpolatedStringHandler handler);
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_arrayToReturnToPool")]
+    static extern ref char[]? ArrayToReturnToPool(ref this DefaultInterpolatedStringHandler handler);
+
+    public static string Test()
+    {
+        var c = new Class(42);
+        GetSetPrivateField(c);
+
+        var buffer = new char[16];
+        var handler = new DefaultInterpolatedStringHandler(literalLength: 10, formattedCount: 2, provider: null, buffer);
+        ref var position = ref handler.Position();
+        position = 2;
+        handler.AppendFormatted(42);
+        return handler.ToStringAndClear();
+    }
+#endif
+}
+
 [TestClass]
 public class InterpolatedStringHandlerTest
 {
+#if NET8_0_OR_GREATER
+    [TestMethod]
+    public void InterpolatedStringHandlerTest_DefaultInterpolatedStringHandler_Accessor()
+    {
+        DefaultInterpolatedStringHandlerAccessor.Test();
+    }
+#endif
+
     [TestMethod]
     public void InterpolatedStringHandlerTest_Log()
     {

--- a/src/Sep.Test/SepWriterColTest.cs
+++ b/src/Sep.Test/SepWriterColTest.cs
@@ -111,6 +111,26 @@ public class SepWriterColTest
         Run(col => col.Format(ColValue));
     }
 
+    [TestMethod]
+    public void SepWriterColTest_Format_Long()
+    {
+        var f = new LongSpanFormattable();
+        Run(col => col.Format(f), f.Text);
+    }
+
+    public class LongSpanFormattable : ISpanFormattable
+    {
+        public string Text { get; } = new('a', 2048);
+
+        public string ToString(string? format, IFormatProvider? formatProvider) => Text;
+
+        public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
+        {
+            charsWritten = Text.Length;
+            return Text.TryCopyTo(destination);
+        }
+    }
+
     // No escaping needed
     [DataRow("", "")]
     [DataRow(" ", " ")]

--- a/src/Sep.Test/SepWriterColTest.cs
+++ b/src/Sep.Test/SepWriterColTest.cs
@@ -75,6 +75,18 @@ public class SepWriterColTest
     }
 
     [TestMethod]
+    public void SepWriterColTest_Set_InterpolatedString_F2_CultureInfoAsConfig_Null()
+    {
+        Run(col => col.Set($"{ColValue:F2}"), ColText + ".00", null);
+    }
+
+    [TestMethod]
+    public void SepWriterColTest_Set_InterpolatedString_F2_CultureInfoAsParam_Null()
+    {
+        Run(col => col.Set(provider: null, $"{ColValue:F2}"), ColText + ".00");
+    }
+
+    [TestMethod]
     public void SepWriterColTest_Set_InterpolatedString_AppendLiteral()
     {
         Run(col => col.Set($"{ColValue} {"Literal"}"), ColText + " Literal");

--- a/src/Sep.Test/SepWriterColTest.cs
+++ b/src/Sep.Test/SepWriterColTest.cs
@@ -10,6 +10,7 @@ public class SepWriterColTest
     const string ColName = "A";
     const int ColValue = 123456;
     const string ColText = "123456";
+    static readonly string ColTextLong = new('a', 2048);
 
     static readonly string NL = Environment.NewLine;
 
@@ -32,9 +33,21 @@ public class SepWriterColTest
     }
 
     [TestMethod]
+    public void SepWriterColTest_Set_String_Long()
+    {
+        Run(col => col.Set(ColTextLong), ColTextLong);
+    }
+
+    [TestMethod]
     public void SepWriterColTest_Set_Span()
     {
         Run(col => col.Set(ColText.AsSpan()));
+    }
+
+    [TestMethod]
+    public void SepWriterColTest_Set_Span_Long()
+    {
+        Run(col => col.Set(ColTextLong.AsSpan()), ColTextLong);
     }
 
     [TestMethod]
@@ -120,7 +133,7 @@ public class SepWriterColTest
 
     public class LongSpanFormattable : ISpanFormattable
     {
-        public string Text { get; } = new('a', 2048);
+        public string Text { get; } = ColTextLong;
 
         public string ToString(string? format, IFormatProvider? formatProvider) => Text;
 

--- a/src/Sep/SepWriter.Col.cs
+++ b/src/Sep/SepWriter.Col.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Buffers;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace nietras.SeparatedValues;
@@ -10,9 +11,9 @@ public partial class SepWriter
     internal sealed class ColImpl
     {
         internal readonly SepWriter _writer;
-        private const int MinimumLength = 64;
-        private char[] _buffer;
-        private int _position;
+        internal const int MinimumLength = 64;
+        internal char[]? _buffer = null;
+        internal int _position;
 
         public ColImpl(SepWriter writer, int index, string name)
         {
@@ -46,160 +47,202 @@ public partial class SepWriter
             return _buffer.AsSpan(0, _position);
         }
 
+        [MemberNotNull(nameof(_buffer))]
         private void EnsureCapacity(int additionalLength)
         {
-            if (_position + additionalLength > _buffer.Length)
+            if (_buffer is null || _position + additionalLength > _buffer.Length)
             {
                 GrowBuffer(additionalLength);
             }
         }
 
+        [MemberNotNull(nameof(_buffer))]
         private void GrowBuffer(int additionalLength)
         {
-            int newSize = Math.Max(_buffer.Length * 2, _position + additionalLength);
-            char[] newBuffer = ArrayPool<char>.Shared.Rent(newSize);
-            _buffer.AsSpan(0, _position).CopyTo(newBuffer);
-            ArrayPool<char>.Shared.Return(_buffer);
-            _buffer = newBuffer;
+            if (_buffer is not null)
+            {
+                int newSize = Math.Max(_buffer.Length * 2, _position + additionalLength);
+                char[] newBuffer = ArrayPool<char>.Shared.Rent(newSize);
+                _buffer.AsSpan(0, _position).CopyTo(newBuffer);
+                ArrayPool<char>.Shared.Return(_buffer);
+                _buffer = newBuffer;
+            }
+            else
+            {
+                _buffer = ArrayPool<char>.Shared.Rent(MinimumLength);
+            }
         }
 
         public void Dispose()
         {
-            ArrayPool<char>.Shared.Return(_buffer);
-            _buffer = null!;
-        }
-
-        [InterpolatedStringHandler]
-        public ref struct AppendInterpolatedStringHandler
-        {
-            readonly ColImpl _builder;
-            readonly IFormatProvider? _provider;
-
-            public AppendInterpolatedStringHandler(int literalLength, int formattedCount, ColImpl builder, IFormatProvider? provider = null)
+            if (_buffer is not null)
             {
-                _builder = builder;
-                _provider = provider;
-            }
-
-            public void AppendLiteral(string value)
-            {
-                _builder.Append(value.AsSpan());
-            }
-
-            public void AppendFormatted<T>(T value)
-            {
-                if (value is IFormattable formattable)
-                {
-                    _builder.Append(formattable.ToString(null, _provider).AsSpan());
-                }
-                else
-                {
-                    _builder.Append(value?.ToString() ?? ReadOnlySpan<char>.Empty);
-                }
-            }
-
-            public void AppendFormatted<T>(T value, string? format)
-            {
-                if (value is IFormattable formattable)
-                {
-                    _builder.Append(formattable.ToString(format, _provider).AsSpan());
-                }
-                else
-                {
-                    _builder.Append(value?.ToString() ?? ReadOnlySpan<char>.Empty);
-                }
-            }
-
-            public void AppendFormatted<T>(T value, int alignment)
-            {
-                AppendFormatted(value, alignment, null);
-            }
-
-            public void AppendFormatted<T>(T value, int alignment, string? format)
-            {
-                string? formattedValue;
-                if (value is IFormattable formattable)
-                {
-                    formattedValue = formattable.ToString(format, _provider);
-                }
-                else
-                {
-                    formattedValue = value?.ToString();
-                }
-
-                if (formattedValue != null)
-                {
-                    if (alignment > 0)
-                    {
-                        _builder.Append(formattedValue.PadLeft(alignment).AsSpan());
-                    }
-                    else if (alignment < 0)
-                    {
-                        _builder.Append(formattedValue.PadRight(-alignment).AsSpan());
-                    }
-                    else
-                    {
-                        _builder.Append(formattedValue.AsSpan());
-                    }
-                }
-            }
-
-            public void AppendFormatted(ReadOnlySpan<char> value)
-            {
-                _builder.Append(value);
-            }
-
-            public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null)
-            {
-                if (alignment > 0)
-                {
-                    _builder.Append(value.ToString().PadLeft(alignment).AsSpan());
-                }
-                else if (alignment < 0)
-                {
-                    _builder.Append(value.ToString().PadRight(-alignment).AsSpan());
-                }
-                else
-                {
-                    _builder.Append(value);
-                }
-            }
-
-            public void AppendFormatted(string? value)
-            {
-                if (value != null)
-                {
-                    _builder.Append(value.AsSpan());
-                }
-            }
-
-            public void AppendFormatted(string? value, int alignment = 0, string? format = null)
-            {
-                if (value != null)
-                {
-                    if (alignment > 0)
-                    {
-                        _builder.Append(value.PadLeft(alignment).AsSpan());
-                    }
-                    else if (alignment < 0)
-                    {
-                        _builder.Append(value.PadRight(-alignment).AsSpan());
-                    }
-                    else
-                    {
-                        _builder.Append(value.AsSpan());
-                    }
-                }
-            }
-
-            public void AppendFormatted(object? value, int alignment = 0, string? format = null)
-            {
-                if (value != null)
-                {
-                    AppendFormatted(value.ToString().AsSpan(), alignment, format);
-                }
+                ArrayPool<char>.Shared.Return(_buffer);
+                _buffer = null;
             }
         }
+
+        //[InterpolatedStringHandler]
+        //public ref struct AppendInterpolatedStringHandler
+        //{
+        //    readonly ColImpl _builder;
+        //    DefaultInterpolatedStringHandler _defaultHandler;
+        //    //readonly IFormatProvider? _provider;
+
+        //    public AppendInterpolatedStringHandler(int literalLength, int formattedCount, ColImpl builder, IFormatProvider? provider = null)
+        //    {
+        //        A.Assert(builder._buffer is not null || (builder._buffer is null && builder._position == 0));
+        //        _builder = builder;
+        //        _defaultHandler = new(literalLength, formattedCount, provider, builder._buffer ?? default);
+        //        ArrayToReturnToPool(ref _defaultHandler) = builder._buffer;
+        //        Position(ref _defaultHandler) = builder._position;
+        //        //_provider = provider;
+        //    }
+
+        //    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        //    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_pos")]
+        //    static extern ref int Position(ref DefaultInterpolatedStringHandler handler);
+        //    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        //    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_arrayToReturnToPool")]
+        //    static extern ref char[]? ArrayToReturnToPool(ref DefaultInterpolatedStringHandler handler);
+
+        //    public void AppendLiteral(string value)
+        //    {
+        //        _defaultHandler.AppendLiteral(value);
+        //        //_builder.Append(value.AsSpan());
+        //    }
+
+        //    public void AppendFormatted<T>(T value)
+        //    {
+        //        _defaultHandler.AppendFormatted(value);
+        //        //if (value is IFormattable formattable)
+        //        //{
+        //        //    _builder.Append(formattable.ToString(null, _provider).AsSpan());
+        //        //}
+        //        //else
+        //        //{
+        //        //    _builder.Append(value?.ToString() ?? ReadOnlySpan<char>.Empty);
+        //        //}
+        //    }
+
+        //    public void AppendFormatted<T>(T value, string? format)
+        //    {
+        //        _defaultHandler.AppendFormatted(value, format);
+        //        //if (value is IFormattable formattable)
+        //        //{
+        //        //    _builder.Append(formattable.ToString(format, _provider).AsSpan());
+        //        //}
+        //        //else
+        //        //{
+        //        //    _builder.Append(value?.ToString() ?? ReadOnlySpan<char>.Empty);
+        //        //}
+        //    }
+
+        //    public void AppendFormatted<T>(T value, int alignment)
+        //    {
+        //        _defaultHandler.AppendFormatted(value, alignment);
+        //        //AppendFormatted(value, alignment, null);
+        //    }
+
+        //    public void AppendFormatted<T>(T value, int alignment, string? format)
+        //    {
+        //        _defaultHandler.AppendFormatted(value, alignment, format);
+        //        //string? formattedValue;
+        //        //if (value is IFormattable formattable)
+        //        //{
+        //        //    formattedValue = formattable.ToString(format, _provider);
+        //        //}
+        //        //else
+        //        //{
+        //        //    formattedValue = value?.ToString();
+        //        //}
+        //        //if (formattedValue != null)
+        //        //{
+        //        //    if (alignment > 0)
+        //        //    {
+        //        //        _builder.Append(formattedValue.PadLeft(alignment).AsSpan());
+        //        //    }
+        //        //    else if (alignment < 0)
+        //        //    {
+        //        //        _builder.Append(formattedValue.PadRight(-alignment).AsSpan());
+        //        //    }
+        //        //    else
+        //        //    {
+        //        //        _builder.Append(formattedValue.AsSpan());
+        //        //    }
+        //        //}
+        //    }
+
+        //    public void AppendFormatted(ReadOnlySpan<char> value)
+        //    {
+        //        _defaultHandler.AppendFormatted(value);
+        //        //_builder.Append(value);
+        //    }
+
+        //    public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null)
+        //    {
+        //        _defaultHandler.AppendFormatted(value, alignment, format);
+        //        //if (alignment > 0)
+        //        //{
+        //        //    _builder.Append(value.ToString().PadLeft(alignment).AsSpan());
+        //        //}
+        //        //else if (alignment < 0)
+        //        //{
+        //        //    _builder.Append(value.ToString().PadRight(-alignment).AsSpan());
+        //        //}
+        //        //else
+        //        //{
+        //        //    _builder.Append(value);
+        //        //}
+        //    }
+
+        //    public void AppendFormatted(string? value)
+        //    {
+        //        _defaultHandler.AppendFormatted(value);
+        //        //if (value != null)
+        //        //{
+        //        //    _builder.Append(value.AsSpan());
+        //        //}
+        //    }
+
+        //    public void AppendFormatted(string? value, int alignment = 0, string? format = null)
+        //    {
+        //        _defaultHandler.AppendFormatted(value, alignment, format);
+        //        //if (value != null)
+        //        //{
+        //        //    if (alignment > 0)
+        //        //    {
+        //        //        _builder.Append(value.PadLeft(alignment).AsSpan());
+        //        //    }
+        //        //    else if (alignment < 0)
+        //        //    {
+        //        //        _builder.Append(value.PadRight(-alignment).AsSpan());
+        //        //    }
+        //        //    else
+        //        //    {
+        //        //        _builder.Append(value.AsSpan());
+        //        //    }
+        //        //}
+        //    }
+
+        //    public void AppendFormatted(object? value, int alignment = 0, string? format = null)
+        //    {
+        //        _defaultHandler.AppendFormatted(value, alignment, format);
+        //        //if (value != null)
+        //        //{
+        //        //    AppendFormatted(value.ToString().AsSpan(), alignment, format);
+        //        //}
+        //    }
+
+        //    internal void Finish()
+        //    {
+        //        ref var handlerArrayRef = ref ArrayToReturnToPool(ref _defaultHandler);
+        //        _builder._buffer = handlerArrayRef;
+        //        _builder._position = Position(ref _defaultHandler);
+        //        handlerArrayRef = null;
+        //        _defaultHandler = default;
+        //    }
+        //}
     }
 
 #pragma warning disable CA1815 // Override equals and operator equals on value types
@@ -223,7 +266,9 @@ public partial class SepWriter
 #pragma warning restore CA1045 // Do not pass types by reference
 #pragma warning restore IDE0060 // Remove unused parameter
 #pragma warning restore CA1822 // Mark members as static
-        { }
+        {
+            handler.Finish();
+        }
 
 #pragma warning disable CA1822 // Mark members as static
 #pragma warning disable IDE0060 // Remove unused parameter
@@ -233,7 +278,9 @@ public partial class SepWriter
 #pragma warning restore CA1045 // Do not pass types by reference
 #pragma warning restore IDE0060 // Remove unused parameter
 #pragma warning restore CA1822 // Mark members as static
-        { }
+        {
+            handler.Finish();
+        }
 
         public void Set(ReadOnlySpan<char> span)
         {
@@ -247,8 +294,19 @@ public partial class SepWriter
         {
             var impl = _impl;
             impl.Clear();
-            var handler = new ColImpl.AppendInterpolatedStringHandler(0, 1, impl, impl._writer._cultureInfo);
-            handler.AppendFormatted(value);
+            if (value.TryFormat(impl._buffer, out var charsWritten, null, impl._writer._cultureInfo))
+            {
+                impl._position = charsWritten;
+            }
+            else
+            {
+                var handler = new FormatInterpolatedStringHandler(0, 1, this);
+                handler.AppendFormatted(value);
+                handler.Finish();
+            }
+            //var handler = new ColImpl.AppendInterpolatedStringHandler(0, 1, impl, impl._writer._cultureInfo);
+            //handler.AppendFormatted(value);
+            //handler.Finish();
             MarkSet();
         }
 
@@ -256,24 +314,40 @@ public partial class SepWriter
         [EditorBrowsable(EditorBrowsableState.Never)]
         [InterpolatedStringHandler]
 #pragma warning disable CA1815 // Override equals and operator equals on value types
-        public readonly ref struct FormatInterpolatedStringHandler
+        public ref struct FormatInterpolatedStringHandler
 #pragma warning restore CA1815 // Override equals and operator equals on value types
         {
             readonly ColImpl _impl;
-            readonly ColImpl.AppendInterpolatedStringHandler _handler;
+            DefaultInterpolatedStringHandler _handler;
+            //readonly ColImpl.AppendInterpolatedStringHandler _handler;
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_pos")]
+            static extern ref int Position(ref DefaultInterpolatedStringHandler handler);
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_arrayToReturnToPool")]
+            static extern ref char[]? ArrayToReturnToPool(ref DefaultInterpolatedStringHandler handler);
 
             public FormatInterpolatedStringHandler(int literalLength, int formattedCount, Col col)
             {
                 _impl = col._impl;
                 _impl.Clear();
-                _handler = new(literalLength, formattedCount, _impl, _impl._writer._cultureInfo);
+                //_handler = new(literalLength, formattedCount, _impl, _impl._writer._cultureInfo);
+                _handler = new(literalLength, formattedCount, _impl._writer._cultureInfo, _impl._buffer);
+                Position(ref _handler) = _impl._position;
+                ArrayToReturnToPool(ref _handler) = _impl._buffer;
+                //_provider = provider;
             }
+
 
             public FormatInterpolatedStringHandler(int literalLength, int formattedCount, Col col, IFormatProvider? provider)
             {
                 _impl = col._impl;
                 _impl.Clear();
-                _handler = new(literalLength, formattedCount, _impl, provider);
+                _handler = new(literalLength, formattedCount, provider, _impl._buffer);
+                Position(ref _handler) = _impl._position;
+                ArrayToReturnToPool(ref _handler) = _impl._buffer;
+                //_handler = new(literalLength, formattedCount, _impl, provider);
             }
 
             public void AppendLiteral(string value)
@@ -336,7 +410,17 @@ public partial class SepWriter
                 MarkSet();
             }
 
-            void MarkSet() => _impl.HasBeenSet = true;
+            void MarkSet() { _impl.HasBeenSet = true; }//Finish(); }
+
+            internal void Finish()
+            //=> _handler.Finish();
+            {
+                ref var handlerArrayRef = ref ArrayToReturnToPool(ref _handler);
+                _impl._buffer = handlerArrayRef;
+                _impl._position = Position(ref _handler);
+                handlerArrayRef = null;
+                _handler = default;
+            }
         }
 
         void MarkSet() => _impl.HasBeenSet = true;

--- a/src/Sep/SepWriter.Col.cs
+++ b/src/Sep/SepWriter.Col.cs
@@ -127,7 +127,6 @@ public partial class SepWriter
         {
             readonly ColImpl _impl;
             DefaultInterpolatedStringHandler _handler;
-            //readonly ColImpl.AppendInterpolatedStringHandler _handler;
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_pos")]
@@ -140,11 +139,9 @@ public partial class SepWriter
             {
                 _impl = col._impl;
                 _impl.Clear();
-                //_handler = new(literalLength, formattedCount, _impl, _impl._writer._cultureInfo);
                 _handler = new(literalLength, formattedCount, _impl._writer._cultureInfo, _impl._buffer);
                 Position(ref _handler) = _impl._position;
                 ArrayToReturnToPool(ref _handler) = _impl._buffer;
-                //_provider = provider;
             }
 
 
@@ -155,7 +152,6 @@ public partial class SepWriter
                 _handler = new(literalLength, formattedCount, provider, _impl._buffer);
                 Position(ref _handler) = _impl._position;
                 ArrayToReturnToPool(ref _handler) = _impl._buffer;
-                //_handler = new(literalLength, formattedCount, _impl, provider);
             }
 
             public void AppendLiteral(string value)

--- a/src/Sep/SepWriter.Col.cs
+++ b/src/Sep/SepWriter.Col.cs
@@ -54,168 +54,6 @@ public partial class SepWriter
             ArrayPool<char>.Shared.Return(_buffer);
             _buffer = newBuffer;
         }
-
-        //[InterpolatedStringHandler]
-        //public ref struct AppendInterpolatedStringHandler
-        //{
-        //    readonly ColImpl _builder;
-        //    DefaultInterpolatedStringHandler _defaultHandler;
-        //    //readonly IFormatProvider? _provider;
-
-        //    public AppendInterpolatedStringHandler(int literalLength, int formattedCount, ColImpl builder, IFormatProvider? provider = null)
-        //    {
-        //        A.Assert(builder._buffer is not null || (builder._buffer is null && builder._position == 0));
-        //        _builder = builder;
-        //        _defaultHandler = new(literalLength, formattedCount, provider, builder._buffer ?? default);
-        //        ArrayToReturnToPool(ref _defaultHandler) = builder._buffer;
-        //        Position(ref _defaultHandler) = builder._position;
-        //        //_provider = provider;
-        //    }
-
-        //    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        //    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_pos")]
-        //    static extern ref int Position(ref DefaultInterpolatedStringHandler handler);
-        //    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        //    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_arrayToReturnToPool")]
-        //    static extern ref char[]? ArrayToReturnToPool(ref DefaultInterpolatedStringHandler handler);
-
-        //    public void AppendLiteral(string value)
-        //    {
-        //        _defaultHandler.AppendLiteral(value);
-        //        //_builder.Append(value.AsSpan());
-        //    }
-
-        //    public void AppendFormatted<T>(T value)
-        //    {
-        //        _defaultHandler.AppendFormatted(value);
-        //        //if (value is IFormattable formattable)
-        //        //{
-        //        //    _builder.Append(formattable.ToString(null, _provider).AsSpan());
-        //        //}
-        //        //else
-        //        //{
-        //        //    _builder.Append(value?.ToString() ?? ReadOnlySpan<char>.Empty);
-        //        //}
-        //    }
-
-        //    public void AppendFormatted<T>(T value, string? format)
-        //    {
-        //        _defaultHandler.AppendFormatted(value, format);
-        //        //if (value is IFormattable formattable)
-        //        //{
-        //        //    _builder.Append(formattable.ToString(format, _provider).AsSpan());
-        //        //}
-        //        //else
-        //        //{
-        //        //    _builder.Append(value?.ToString() ?? ReadOnlySpan<char>.Empty);
-        //        //}
-        //    }
-
-        //    public void AppendFormatted<T>(T value, int alignment)
-        //    {
-        //        _defaultHandler.AppendFormatted(value, alignment);
-        //        //AppendFormatted(value, alignment, null);
-        //    }
-
-        //    public void AppendFormatted<T>(T value, int alignment, string? format)
-        //    {
-        //        _defaultHandler.AppendFormatted(value, alignment, format);
-        //        //string? formattedValue;
-        //        //if (value is IFormattable formattable)
-        //        //{
-        //        //    formattedValue = formattable.ToString(format, _provider);
-        //        //}
-        //        //else
-        //        //{
-        //        //    formattedValue = value?.ToString();
-        //        //}
-        //        //if (formattedValue != null)
-        //        //{
-        //        //    if (alignment > 0)
-        //        //    {
-        //        //        _builder.Append(formattedValue.PadLeft(alignment).AsSpan());
-        //        //    }
-        //        //    else if (alignment < 0)
-        //        //    {
-        //        //        _builder.Append(formattedValue.PadRight(-alignment).AsSpan());
-        //        //    }
-        //        //    else
-        //        //    {
-        //        //        _builder.Append(formattedValue.AsSpan());
-        //        //    }
-        //        //}
-        //    }
-
-        //    public void AppendFormatted(ReadOnlySpan<char> value)
-        //    {
-        //        _defaultHandler.AppendFormatted(value);
-        //        //_builder.Append(value);
-        //    }
-
-        //    public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null)
-        //    {
-        //        _defaultHandler.AppendFormatted(value, alignment, format);
-        //        //if (alignment > 0)
-        //        //{
-        //        //    _builder.Append(value.ToString().PadLeft(alignment).AsSpan());
-        //        //}
-        //        //else if (alignment < 0)
-        //        //{
-        //        //    _builder.Append(value.ToString().PadRight(-alignment).AsSpan());
-        //        //}
-        //        //else
-        //        //{
-        //        //    _builder.Append(value);
-        //        //}
-        //    }
-
-        //    public void AppendFormatted(string? value)
-        //    {
-        //        _defaultHandler.AppendFormatted(value);
-        //        //if (value != null)
-        //        //{
-        //        //    _builder.Append(value.AsSpan());
-        //        //}
-        //    }
-
-        //    public void AppendFormatted(string? value, int alignment = 0, string? format = null)
-        //    {
-        //        _defaultHandler.AppendFormatted(value, alignment, format);
-        //        //if (value != null)
-        //        //{
-        //        //    if (alignment > 0)
-        //        //    {
-        //        //        _builder.Append(value.PadLeft(alignment).AsSpan());
-        //        //    }
-        //        //    else if (alignment < 0)
-        //        //    {
-        //        //        _builder.Append(value.PadRight(-alignment).AsSpan());
-        //        //    }
-        //        //    else
-        //        //    {
-        //        //        _builder.Append(value.AsSpan());
-        //        //    }
-        //        //}
-        //    }
-
-        //    public void AppendFormatted(object? value, int alignment = 0, string? format = null)
-        //    {
-        //        _defaultHandler.AppendFormatted(value, alignment, format);
-        //        //if (value != null)
-        //        //{
-        //        //    AppendFormatted(value.ToString().AsSpan(), alignment, format);
-        //        //}
-        //    }
-
-        //    internal void Finish()
-        //    {
-        //        ref var handlerArrayRef = ref ArrayToReturnToPool(ref _defaultHandler);
-        //        _builder._buffer = handlerArrayRef;
-        //        _builder._position = Position(ref _defaultHandler);
-        //        handlerArrayRef = null;
-        //        _defaultHandler = default;
-        //    }
-        //}
     }
 
 #pragma warning disable CA1815 // Override equals and operator equals on value types
@@ -277,9 +115,6 @@ public partial class SepWriter
                 handler.AppendFormatted(value);
                 handler.Finish();
             }
-            //var handler = new ColImpl.AppendInterpolatedStringHandler(0, 1, impl, impl._writer._cultureInfo);
-            //handler.AppendFormatted(value);
-            //handler.Finish();
             MarkSet();
         }
 
@@ -383,13 +218,13 @@ public partial class SepWriter
                 MarkSet();
             }
 
-            void MarkSet() { _impl.HasBeenSet = true; }//Finish(); }
+            void MarkSet() => _impl.HasBeenSet = true;
 
             internal void Finish()
-            //=> _handler.Finish();
             {
                 ref var handlerArrayRef = ref ArrayToReturnToPool(ref _handler);
-                _impl._buffer = handlerArrayRef;
+                A.Assert(handlerArrayRef is not null);
+                _impl._buffer = handlerArrayRef!;
                 _impl._position = Position(ref _handler);
                 handlerArrayRef = null;
                 _handler = default;

--- a/src/Sep/SepWriter.Col.cs
+++ b/src/Sep/SepWriter.Col.cs
@@ -75,7 +75,7 @@ public partial class SepWriter
             handler.Finish();
         }
         public void Set(IFormatProvider? provider,
-            [InterpolatedStringHandlerArgument("", "provider")] ref FormatInterpolatedStringHandler handler)
+            [InterpolatedStringHandlerArgument("", nameof(provider))] ref FormatInterpolatedStringHandler handler)
         {
             handler.Finish();
         }

--- a/src/Sep/SepWriter.cs
+++ b/src/Sep/SepWriter.cs
@@ -102,10 +102,7 @@ public sealed partial class SepWriter : IDisposable
                 }
                 else
                 {
-                    foreach (var chunk in sb.GetChunks())
-                    {
-                        _writer.Write(chunk.Span);
-                    }
+                    _writer.Write(sb.GetSpan());
                 }
                 notFirst = true;
             }
@@ -160,32 +157,23 @@ public sealed partial class SepWriter : IDisposable
         _headerWrittenOrSkipped = true;
     }
 
-    void WriteEscaped(StringBuilder sb)
+    void WriteEscaped(ColBuilder sb)
     {
         var separator = _sep.Separator;
         uint containsSpecialChar = 0;
 
-        foreach (var chunk in sb.GetChunks())
-        {
-            containsSpecialChar |= ContainsSpecialCharacters(chunk.Span, separator);
-            if (containsSpecialChar != 0) { break; }
-        }
+        var span = sb.GetSpan();
+        containsSpecialChar |= ContainsSpecialCharacters(span, separator);
 
         if (containsSpecialChar != 0)
         {
             _writer.Write(SepDefaults.Quote);
-            foreach (var chunk in sb.GetChunks())
-            {
-                WriteQuotesEscaped(chunk.Span);
-            }
+            WriteQuotesEscaped(span);
             _writer.Write(SepDefaults.Quote);
         }
         else
         {
-            foreach (var chunk in sb.GetChunks())
-            {
-                _writer.Write(chunk.Span);
-            }
+            _writer.Write(span);
         }
     }
 
@@ -282,7 +270,7 @@ public sealed partial class SepWriter : IDisposable
         _arrayPool.Dispose();
         foreach (var col in _colNameToCol.Values)
         {
-            SepStringBuilderPool.Return(col.Text);
+            col.Text.Dispose();
         }
         _colNameToCol.Clear();
     }

--- a/src/Sep/SepWriter.cs
+++ b/src/Sep/SepWriter.cs
@@ -95,14 +95,14 @@ public sealed partial class SepWriter : IDisposable
                 {
                     _writer.Write(_sep.Separator);
                 }
-                var sb = col.Text;
+                var span = col.GetSpan();
                 if (_escape)
                 {
-                    WriteEscaped(sb);
+                    WriteEscaped(span);
                 }
                 else
                 {
-                    _writer.Write(sb.GetSpan());
+                    _writer.Write(span);
                 }
                 notFirst = true;
             }
@@ -155,26 +155,6 @@ public sealed partial class SepWriter : IDisposable
             _writer.WriteLine();
         }
         _headerWrittenOrSkipped = true;
-    }
-
-    void WriteEscaped(ColBuilder sb)
-    {
-        var separator = _sep.Separator;
-        uint containsSpecialChar = 0;
-
-        var span = sb.GetSpan();
-        containsSpecialChar |= ContainsSpecialCharacters(span, separator);
-
-        if (containsSpecialChar != 0)
-        {
-            _writer.Write(SepDefaults.Quote);
-            WriteQuotesEscaped(span);
-            _writer.Write(SepDefaults.Quote);
-        }
-        else
-        {
-            _writer.Write(span);
-        }
     }
 
     void WriteEscaped(ReadOnlySpan<char> span)
@@ -270,7 +250,7 @@ public sealed partial class SepWriter : IDisposable
         _arrayPool.Dispose();
         foreach (var col in _colNameToCol.Values)
         {
-            col.Text.Dispose();
+            col.Dispose();
         }
         _colNameToCol.Clear();
     }


### PR DESCRIPTION
Use UnsafeAccessor for DefaultInterpolatedStringHandler to let this handle array from ArrayPool incl. growing size (much simpler)