### PR TITLE
Remove net7.0 target

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ﻿# Sep - ~~Possibly~~ the World's Fastest .NET CSV Parser
-![.NET](https://img.shields.io/badge/net7.0%20net8.0%20net9.0-5C2D91?logo=.NET&labelColor=gray)
+![.NET](https://img.shields.io/badge/net8.0%20net9.0-5C2D91?logo=.NET&labelColor=gray)
 ![C#](https://img.shields.io/badge/C%23-13.0-239120?labelColor=gray)
 [![Build Status](https://github.com/nietras/Sep/actions/workflows/dotnet.yml/badge.svg?branch=main)](https://github.com/nietras/Sep/actions/workflows/dotnet.yml)
 [![Super-Linter](https://github.com/nietras/Sep/actions/workflows/super-linter.yml/badge.svg)](https://github.com/marketplace/actions/super-linter)

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,7 +10,7 @@
     <Copyright>Copyright © nietras A/S 2023</Copyright>
     <NeutralLanguage>en</NeutralLanguage>
 
-    <TargetFrameworks>net9.0;net8.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
 
     <LangVersion>13.0</LangVersion>

--- a/src/Sep.XyzTest/Sep.XyzTest.csproj
+++ b/src/Sep.XyzTest/Sep.XyzTest.csproj
@@ -4,10 +4,6 @@
     <RootNamespace>nietras.SeparatedValues.XyzTest</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>false</IsPackable>
-
-    <!-- PublicApiGenerator references System.CodeDom which annoying warns about
-         net7.0 so have to suppress all -->
-    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Sep/CompatibilitySuppressions.xml
+++ b/src/Sep/CompatibilitySuppressions.xml
@@ -1,4 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>PKV006</DiagnosticId>
+    <Target>net7.0</Target>
+  </Suppression>
 </Suppressions>


### PR DESCRIPTION
Upcoming changes/refactorings will require using `UnsafeAccessor` to make `SepWriter` simpler and more efficient which is only available in net8.0+ so dropping .NET 7 support. If any users of Sep have an issue with this please chime in in this PR and why can't upgrade to .NET 8 or similar. 