### PR TITLE
SepReader: Replace Peek with Read/ReadAsync for line ending check

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![Super-Linter](https://github.com/nietras/Sep/actions/workflows/super-linter.yml/badge.svg)](https://github.com/marketplace/actions/super-linter)
 [![codecov](https://codecov.io/gh/nietras/Sep/branch/main/graph/badge.svg?token=WN56CR3X0D)](https://codecov.io/gh/nietras/Sep)
 [![CodeQL](https://github.com/nietras/Sep/workflows/CodeQL/badge.svg)](https://github.com/nietras/Sep/actions?query=workflow%3ACodeQL)
-[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9962/badge)](https://www.bestpractices.dev/projects/9962)
 [![Nuget](https://img.shields.io/nuget/v/Sep?color=purple)](https://www.nuget.org/packages/Sep/)
 [![Release](https://img.shields.io/github/v/release/nietras/Sep)](https://github.com/nietras/Sep/releases/)
 [![downloads](https://img.shields.io/nuget/dt/Sep)](https://www.nuget.org/packages/Sep)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Super-Linter](https://github.com/nietras/Sep/actions/workflows/super-linter.yml/badge.svg)](https://github.com/marketplace/actions/super-linter)
 [![codecov](https://codecov.io/gh/nietras/Sep/branch/main/graph/badge.svg?token=WN56CR3X0D)](https://codecov.io/gh/nietras/Sep)
 [![CodeQL](https://github.com/nietras/Sep/workflows/CodeQL/badge.svg)](https://github.com/nietras/Sep/actions?query=workflow%3ACodeQL)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9962/badge)](https://www.bestpractices.dev/projects/9962)
 [![Nuget](https://img.shields.io/nuget/v/Sep?color=purple)](https://www.nuget.org/packages/Sep/)
 [![Release](https://img.shields.io/github/v/release/nietras/Sep)](https://github.com/nietras/Sep/releases/)
 [![downloads](https://img.shields.io/nuget/dt/Sep)](https://www.nuget.org/packages/Sep)

--- a/README.md
+++ b/README.md
@@ -2188,6 +2188,7 @@ namespace nietras.SeparatedValues
     public readonly struct SepSpec : System.IEquatable<nietras.SeparatedValues.SepSpec>
     {
         public SepSpec() { }
+        public SepSpec(nietras.SeparatedValues.Sep sep, System.Globalization.CultureInfo? cultureInfo) { }
         public SepSpec(nietras.SeparatedValues.Sep sep, System.Globalization.CultureInfo? cultureInfo, bool asyncContinueOnCapturedContext) { }
         public bool AsyncContinueOnCapturedContext { get; init; }
         public System.Globalization.CultureInfo? CultureInfo { get; init; }

--- a/src/Sep/SepReader.IO.Async.cs
+++ b/src/Sep/SepReader.IO.Async.cs
@@ -319,42 +319,75 @@ public sealed partial class SepReader
         A.Assert(freeLength > 0, $"Free span at end of buffer length {freeLength} not greater than 0");
 
         // Read until full or no more data
-        var totalBytesRead = 0;
+        var totalReadCount = 0;
         var readCount = 0;
+
+        // If trailing char is '\r' ensire added to buffer
+        if (_trailingChar == CarriageReturn)
+        {
 #if SYNC
-        while (totalBytesRead < freeLength &&
-               ((readCount = _reader.Read(freeChars.Slice(totalBytesRead))) > 0))
+            freeChars[0] = CarriageReturn;
 #else
-        while (totalBytesRead < freeLength &&
-                ((readCount = await _reader.ReadAsync(freeChars.Slice(totalBytesRead), cancellationToken)
+            freeChars.Span[0] = CarriageReturn;
+#endif
+            _trailingChar = '\0';
+            ++totalReadCount;
+            ++_charsDataEnd;
+        }
+
+#if SYNC
+        while (totalReadCount < freeLength &&
+               ((readCount = _reader.Read(freeChars.Slice(totalReadCount))) > 0))
+#else
+        while (totalReadCount < freeLength &&
+                ((readCount = await _reader.ReadAsync(freeChars.Slice(totalReadCount), cancellationToken)
                     .ConfigureAwait(_continueOnCapturedContext)) > 0))
 #endif
         {
             _charsDataEnd += readCount;
+            totalReadCount += readCount;
             // Ensure carriage return always followed by line feed
             if (_chars[_charsDataEnd - 1] == CarriageReturn)
             {
-                var extraChar = _reader.Peek();
-                if (extraChar == LineFeed)
+                // Do not use freeChars as this has length exactly 1 less than
+                // available so we can here read that extra char after a
+                // carriage return.
+#if SYNC
+                var extraReadChars = _chars.AsSpan(_charsDataEnd, length: 1);
+                var extraReadCount = _reader.Read(extraReadChars);
+#else
+                var extraReadChars = _chars.AsMemory(_charsDataEnd, length: 1);
+                var extraReadCount = await _reader.ReadAsync(extraReadChars, cancellationToken)
+                    .ConfigureAwait(_continueOnCapturedContext);
+#endif
+                if (extraReadCount > 0)
                 {
-                    var readChar = (char)_reader.Read();
-                    //#if SYNC
-                    //                    var readChar = (char)_reader.Read();
-                    //#else
-                    //                    var readChar = (char)await _reader.ReadAsync();
-                    //#endif
-                    A.Assert(extraChar == readChar);
-                    _chars[_charsDataEnd] = readChar;
-                    ++_charsDataEnd;
-                    ++readCount;
+                    A.Assert(extraReadCount == 1);
+#if SYNC
+                    var readChar = extraReadChars[0];
+#else
+                    var readChar = extraReadChars.Span[0];
+#endif
+                    if (readChar != CarriageReturn)
+                    {
+                        ++_charsDataEnd;
+                        ++totalReadCount;
+                    }
+                    else
+                    {
+                        // Reset read char
+                        _chars[_charsDataEnd] = '\0';
+                        // Set aside next carriage return for next read
+                        A.Assert(readChar == CarriageReturn);
+                        _trailingChar = readChar;
+                    }
                 }
             }
-            totalBytesRead += readCount;
         }
         if (paddingLength > 0)
         {
             _chars.ClearPaddingAfterData(_charsDataEnd, paddingLength);
         }
-        return totalBytesRead == 0;
+        return totalReadCount == 0 && _trailingChar != CarriageReturn;
     }
 }

--- a/src/Sep/SepReader.IO.Async.cs
+++ b/src/Sep/SepReader.IO.Async.cs
@@ -346,7 +346,9 @@ public sealed partial class SepReader
         {
             _charsDataEnd += readCount;
             totalReadCount += readCount;
-            // Ensure carriage return always followed by line feed
+            // Ensure char after carriage return always available e.g. to ensure
+            // `\r\n` read as one line ending, unless next char is another
+            // carriage return then set it aside as trailing '\r'.
             if (_chars[_charsDataEnd - 1] == CarriageReturn)
             {
                 // Do not use freeChars as this has (length - 1) and here we

--- a/src/Sep/SepReader.IO.Sync.cs
+++ b/src/Sep/SepReader.IO.Sync.cs
@@ -319,42 +319,75 @@ public sealed partial class SepReader
         A.Assert(freeLength > 0, $"Free span at end of buffer length {freeLength} not greater than 0");
 
         // Read until full or no more data
-        var totalBytesRead = 0;
+        var totalReadCount = 0;
         var readCount = 0;
+
+        // If trailing char is '\r' ensire added to buffer
+        if (_trailingChar == CarriageReturn)
+        {
 #if SYNC
-        while (totalBytesRead < freeLength &&
-               ((readCount = _reader.Read(freeChars.Slice(totalBytesRead))) > 0))
+            freeChars[0] = CarriageReturn;
 #else
-        while (totalBytesRead < freeLength &&
-                ((readCount = await _reader.ReadAsync(freeChars.Slice(totalBytesRead), cancellationToken)
+            freeChars.Span[0] = CarriageReturn;
+#endif
+            _trailingChar = '\0';
+            ++totalReadCount;
+            ++_charsDataEnd;
+        }
+
+#if SYNC
+        while (totalReadCount < freeLength &&
+               ((readCount = _reader.Read(freeChars.Slice(totalReadCount))) > 0))
+#else
+        while (totalReadCount < freeLength &&
+                ((readCount = await _reader.ReadAsync(freeChars.Slice(totalReadCount), cancellationToken)
                     .ConfigureAwait(_continueOnCapturedContext)) > 0))
 #endif
         {
             _charsDataEnd += readCount;
+            totalReadCount += readCount;
             // Ensure carriage return always followed by line feed
             if (_chars[_charsDataEnd - 1] == CarriageReturn)
             {
-                var extraChar = _reader.Peek();
-                if (extraChar == LineFeed)
+                // Do not use freeChars as this has length exactly 1 less than
+                // available so we can here read that extra char after a
+                // carriage return.
+#if SYNC
+                var extraReadChars = _chars.AsSpan(_charsDataEnd, length: 1);
+                var extraReadCount = _reader.Read(extraReadChars);
+#else
+                var extraReadChars = _chars.AsMemory(_charsDataEnd, length: 1);
+                var extraReadCount = await _reader.ReadAsync(extraReadChars, cancellationToken)
+                    .ConfigureAwait(_continueOnCapturedContext);
+#endif
+                if (extraReadCount > 0)
                 {
-                    var readChar = (char)_reader.Read();
-                    //#if SYNC
-                    //                    var readChar = (char)_reader.Read();
-                    //#else
-                    //                    var readChar = (char)await _reader.ReadAsync();
-                    //#endif
-                    A.Assert(extraChar == readChar);
-                    _chars[_charsDataEnd] = readChar;
-                    ++_charsDataEnd;
-                    ++readCount;
+                    A.Assert(extraReadCount == 1);
+#if SYNC
+                    var readChar = extraReadChars[0];
+#else
+                    var readChar = extraReadChars.Span[0];
+#endif
+                    if (readChar != CarriageReturn)
+                    {
+                        ++_charsDataEnd;
+                        ++totalReadCount;
+                    }
+                    else
+                    {
+                        // Reset read char
+                        _chars[_charsDataEnd] = '\0';
+                        // Set aside next carriage return for next read
+                        A.Assert(readChar == CarriageReturn);
+                        _trailingChar = readChar;
+                    }
                 }
             }
-            totalBytesRead += readCount;
         }
         if (paddingLength > 0)
         {
             _chars.ClearPaddingAfterData(_charsDataEnd, paddingLength);
         }
-        return totalBytesRead == 0;
+        return totalReadCount == 0 && _trailingChar != CarriageReturn;
     }
 }

--- a/src/Sep/SepReader.IO.Sync.cs
+++ b/src/Sep/SepReader.IO.Sync.cs
@@ -346,7 +346,9 @@ public sealed partial class SepReader
         {
             _charsDataEnd += readCount;
             totalReadCount += readCount;
-            // Ensure carriage return always followed by line feed
+            // Ensure char after carriage return always available e.g. to ensure
+            // `\r\n` read as one line ending, unless next char is another
+            // carriage return then set it aside as trailing '\r'.
             if (_chars[_charsDataEnd - 1] == CarriageReturn)
             {
                 // Do not use freeChars as this has (length - 1) and here we

--- a/src/Sep/SepReaderState.cs
+++ b/src/Sep/SepReaderState.cs
@@ -28,9 +28,9 @@ public class SepReaderState : IDisposable
     internal int _charsDataEnd = 0;
     // To handle '\r\n' reader depends on a pattern of always reading one char
     // past any '\r' and then add this char to buffer if NOT another '\r'. If
-    // '\r' is followed by '\r' the carriage return is put aside here as a
-    // trailing char to be added to buffer before next read.
-    internal char _trailingChar = '\0';
+    // '\r' is followed by '\r' this is indicated by the bool here so the
+    // trailing carriage return can be added to buffer before next read.
+    internal bool _trailingCarriageReturn = false;
 
     internal int _charsParseStart = 0;
 

--- a/src/Sep/SepReaderState.cs
+++ b/src/Sep/SepReaderState.cs
@@ -26,6 +26,11 @@ public class SepReaderState : IDisposable
     internal char[] _chars = Array.Empty<char>();
     internal int _charsDataStart = 0;
     internal int _charsDataEnd = 0;
+    // To handle '\r\n' reader depends on a pattern of always reading one char
+    // past any '\r' and then add this char to buffer if NOT another '\r'. If
+    // '\r' is followed by '\r' the carriage return is put aside here as a
+    // trailing char to be added to buffer before next read.
+    internal char _trailingChar = '\0';
 
     internal int _charsParseStart = 0;
 


### PR DESCRIPTION
Fix intricate issue possible if Peek not implemented or returning -1 even if more data available and better support full async. No known real world issues. 