### PR TITLE
Tweak SepParserAvx512PackCmpOrMoveMaskTzcnt by moving MoveMask

### DIFF
--- a/src/Sep/Internals/SepParserAvx512PackCmpOrMoveMaskTzcnt.cs
+++ b/src/Sep/Internals/SepParserAvx512PackCmpOrMoveMaskTzcnt.cs
@@ -15,7 +15,7 @@ using VecUI8 = System.Runtime.Intrinsics.Vector512<byte>;
 namespace nietras.SeparatedValues;
 
 [ExcludeFromCodeCoverage]
-struct SepParserAvx512PackCmpOrMoveMaskTzcnt : ISepParser
+sealed class SepParserAvx512PackCmpOrMoveMaskTzcnt : ISepParser
 {
     readonly char _separator;
     readonly VecUI8 _nls = Vec.Create(LineFeedByte);

--- a/src/Sep/Internals/SepParserAvx512PackCmpOrMoveMaskTzcnt.cs
+++ b/src/Sep/Internals/SepParserAvx512PackCmpOrMoveMaskTzcnt.cs
@@ -15,7 +15,7 @@ using VecUI8 = System.Runtime.Intrinsics.Vector512<byte>;
 namespace nietras.SeparatedValues;
 
 [ExcludeFromCodeCoverage]
-sealed class SepParserAvx512PackCmpOrMoveMaskTzcnt : ISepParser
+struct SepParserAvx512PackCmpOrMoveMaskTzcnt : ISepParser
 {
     readonly char _separator;
     readonly VecUI8 _nls = Vec.Create(LineFeedByte);

--- a/src/Sep/Internals/SepParserAvx512PackCmpOrMoveMaskTzcnt.cs
+++ b/src/Sep/Internals/SepParserAvx512PackCmpOrMoveMaskTzcnt.cs
@@ -108,20 +108,20 @@ struct SepParserAvx512PackCmpOrMoveMaskTzcnt : ISepParser
             var permuteIndices = Vec.Create(0L, 2L, 4L, 6L, 1L, 3L, 5L, 7L);
             var bytes = ISA.PermuteVar8x64(packed.AsInt64(), permuteIndices).AsByte();
 
-            var nlsEq = Vec.Equals(bytes, nls);
-            var crsEq = Vec.Equals(bytes, crs);
-            var qtsEq = Vec.Equals(bytes, qts);
-            var spsEq = Vec.Equals(bytes, sps);
+            var nlsEq = MoveMask(Vec.Equals(bytes, nls));
+            var crsEq = MoveMask(Vec.Equals(bytes, crs));
+            var qtsEq = MoveMask(Vec.Equals(bytes, qts));
+            var spsEq = MoveMask(Vec.Equals(bytes, sps));
 
             var lineEndings = nlsEq | crsEq;
             var lineEndingsSeparators = spsEq | lineEndings;
             var specialChars = lineEndingsSeparators | qtsEq;
 
             // Optimize for the case of no special character
-            var specialCharMask = MoveMask(specialChars);
+            var specialCharMask = specialChars;
             if (specialCharMask != 0u)
             {
-                var separatorsMask = MoveMask(spsEq);
+                var separatorsMask = spsEq;
                 // Optimize for case of only separators i.e. no endings or quotes.
                 // Add quote count to mask as hack to skip if quoting.
                 var testMask = specialCharMask + quoteCount;
@@ -132,7 +132,7 @@ struct SepParserAvx512PackCmpOrMoveMaskTzcnt : ISepParser
                 }
                 else
                 {
-                    var separatorLineEndingsMask = MoveMask(lineEndingsSeparators);
+                    var separatorLineEndingsMask = lineEndingsSeparators;
                     if (separatorLineEndingsMask == testMask)
                     {
                         colInfosRefCurrent = ref ParseSeparatorsLineEndingsMasks<TColInfo, TColInfoMethods>(


### PR DESCRIPTION
### BEFORE

```ini
BenchmarkDotNet v0.14.0, Windows 10 (10.0.19044.3086/21H2/November2021Update)
AMD Ryzen 9 9950X, 1 CPU, 32 logical and 16 physical cores
.NET SDK 9.0.203
  [Host]     : .NET 9.0.4 (9.0.425.16305), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
  Job-TORZYV : .NET 9.0.4 (9.0.425.16305), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI

Job=Job-TORZYV  EnvironmentVariables=DOTNET_GCDynamicAdaptationMode=0  Runtime=.NET 9.0
Toolchain=net90  InvocationCount=Default  IterationTime=350ms
MaxIterationCount=15  MinIterationCount=5  WarmupCount=6
Quotes=False  Reader=String  Error=0.0153 ms
StdDev=0.0068 ms

| Method    | Scope | Rows  | Mean     | Ratio | MB | MB/s    | ns/row | Allocated | Alloc Ratio |
|---------- |------ |------ |---------:|------:|---:|--------:|-------:|----------:|------------:|
| Sep______ | Row   | 50000 | 1.629 ms |  1.00 | 29 | 17908.5 |   32.6 |   1.17 KB |        1.00 |
```

```nasm
G_M000_IG05:                ;; offset=0x008E
       cmp      rsi, rbp
       jb       G_M000_IG39
       mov      edi, r9d
       lea      rdi, bword ptr [r10+2*rdi]
       vmovups  zmm4, zmmword ptr [rdi]
       vpackuswb zmm4, zmm4, zmmword ptr [rdi+0x40]
       vmovups  zmm5, zmmword ptr [reloc @RWD00]
       vpermq   zmm4, zmm5, zmm4
       vpcmpeqb k1, zmm4, zmm0
       vpmovm2b zmm5, k1
       vpcmpeqb k1, zmm4, zmm1
       vpmovm2b zmm16, k1
       vpcmpeqb k1, zmm4, zmm2
       vpmovm2b zmm17, k1
       vpcmpeqb k1, zmm4, zmm3
       vpmovm2b zmm4, k1
       vpternlogd zmm5, zmm4, zmm16, -2
       vpord    zmm16, zmm5, zmm17
       vpmovb2m k1, zmm16
       kmovq    r15, k1
       test     r15, r15
       je       G_M000_IG03
       vpmovb2m k1, zmm4
       kmovq    r13, k1
       lea      r12, [r15+r8]
       cmp      r13, r12
       je       G_M000_IG43

G_M000_IG06:                ;; offset=0x012A
       vpmovb2m k1, zmm5
       kmovq    rcx, k1
       cmp      rcx, r12
       je       G_M000_IG22

G_M000_IG07:                ;; offset=0x0141
       xor      ecx, ecx
```

### AFTER

```ini
BenchmarkDotNet v0.14.0, Windows 10 (10.0.19044.3086/21H2/November2021Update)
AMD Ryzen 9 9950X, 1 CPU, 32 logical and 16 physical cores
.NET SDK 9.0.203
  [Host]     : .NET 9.0.4 (9.0.425.16305), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
  Job-TKOEXX : .NET 9.0.4 (9.0.425.16305), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI

Job=Job-TKOEXX  EnvironmentVariables=DOTNET_GCDynamicAdaptationMode=0  Runtime=.NET 9.0
Toolchain=net90  InvocationCount=Default  IterationTime=350ms
MaxIterationCount=15  MinIterationCount=5  WarmupCount=6
Quotes=False  Reader=String  Error=0.0108 ms
StdDev=0.0017 ms

| Method    | Scope | Rows  | Mean     | Ratio | MB | MB/s    | ns/row | Allocated | Alloc Ratio |
|---------- |------ |------ |---------:|------:|---:|--------:|-------:|----------:|------------:|
| Sep______ | Row   | 50000 | 1.498 ms |  1.00 | 29 | 19476.8 |   30.0 |   1.23 KB |        1.00 |
```

```nasm
G_M000_IG05:                ;; offset=0x008E
       cmp      rsi, rbp
       jb       G_M000_IG39
       mov      edi, r9d
       lea      rdi, bword ptr [r10+2*rdi]
       vmovups  zmm4, zmmword ptr [rdi]
       vpackuswb zmm4, zmm4, zmmword ptr [rdi+0x40]
       vmovups  zmm5, zmmword ptr [reloc @RWD00]
       vpermq   zmm4, zmm5, zmm4
       vpcmpeqb k1, zmm4, zmm0
       kmovq    r15, k1
       vpcmpeqb k1, zmm4, zmm1
       kmovq    r13, k1
       vpcmpeqb k1, zmm4, zmm2
       kmovq    r12, k1
       vpcmpeqb k1, zmm4, zmm3
       kmovq    rcx, k1
       or       r15, rcx
       or       r15, r13
       or       r12, r15
       je       SHORT G_M000_IG03
       mov      r13, rcx
       lea      rcx, [r12+r8]
       cmp      r13, rcx
       je       G_M000_IG43

G_M000_IG06:                ;; offset=0x010E
       cmp      r15, rcx
       je       G_M000_IG22

G_M000_IG07:                ;; offset=0x0117
       xor      ecx, ecx
```