### PR TITLE
Add SepParserAvx512To256CmpOrMoveMaskTzcnt (new default for AVX-512)

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -41,6 +41,7 @@
     <!--<DefineConstants Condition="'$(Configuration)'=='Debug'">$(DefineConstants);SEPTRACE</DefineConstants>-->
     <DefineConstants Condition="'$(Configuration)'=='Debug'">$(DefineConstants);SEPREADERASSERT</DefineConstants>
     <!--<DefineConstants Condition="'$(Configuration)'=='Debug'">$(DefineConstants);SEPREADERTRACE</DefineConstants>-->
+    <!--<DefineConstants Condition="'$(Configuration)'=='Release'">$(DefineConstants);SEPUSESTRUCTFORPARSERSFORDISASMO</DefineConstants>-->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Sep/Internals/SepParserAvx512PackCmpOrMoveMaskTzcnt.cs
+++ b/src/Sep/Internals/SepParserAvx512PackCmpOrMoveMaskTzcnt.cs
@@ -15,7 +15,12 @@ using VecUI8 = System.Runtime.Intrinsics.Vector512<byte>;
 namespace nietras.SeparatedValues;
 
 [ExcludeFromCodeCoverage]
-sealed class SepParserAvx512PackCmpOrMoveMaskTzcnt : ISepParser
+#if SEPUSESTRUCTFORPARSERSFORDISASMO
+struct
+#else
+sealed class
+#endif
+SepParserAvx512PackCmpOrMoveMaskTzcnt : ISepParser
 {
     readonly char _separator;
     readonly VecUI8 _nls = Vec.Create(LineFeedByte);

--- a/src/Sep/Internals/SepParserFactory.cs
+++ b/src/Sep/Internals/SepParserFactory.cs
@@ -49,7 +49,10 @@ static class SepParserFactory
     {
 #if NET8_0_OR_GREATER
         if (Environment.Is64BitProcess && Avx512BW.IsSupported)
-        { Add(parsers, nameof(SepParserAvx512PackCmpOrMoveMaskTzcnt), static sep => new SepParserAvx512PackCmpOrMoveMaskTzcnt(sep)); }
+        {
+            Add(parsers, nameof(SepParserAvx512To256CmpOrMoveMaskTzcnt), static sep => new SepParserAvx512To256CmpOrMoveMaskTzcnt(sep));
+            Add(parsers, nameof(SepParserAvx512PackCmpOrMoveMaskTzcnt), static sep => new SepParserAvx512PackCmpOrMoveMaskTzcnt(sep));
+        }
         if (Environment.Is64BitProcess && (createUnaccelerated || Vector512.IsHardwareAccelerated))
         { Add(parsers, nameof(SepParserVector512NrwCmpExtMsbTzcnt), static sep => new SepParserVector512NrwCmpExtMsbTzcnt(sep)); }
 #endif

--- a/test-parsers.ps1
+++ b/test-parsers.ps1
@@ -1,6 +1,7 @@
 #!/usr/bin/env pwsh
 Try {
     $parsers = @(
+        "SepParserAvx512To256CmpOrMoveMaskTzcnt",
         "SepParserAvx512PackCmpOrMoveMaskTzcnt",
         "SepParserAvx2PackCmpOrMoveMaskTzcnt",
         "SepParserSse2PackCmpOrMoveMaskTzcnt",


### PR DESCRIPTION
New better approach for AVX-512 due to mask register code gen issues. Hits ~21 GB/s on a good day! 

```ini
BenchmarkDotNet v0.14.0, Windows 10 (10.0.19044.3086/21H2/November2021Update)
AMD Ryzen 9 9950X, 1 CPU, 32 logical and 16 physical cores
.NET SDK 9.0.203
  [Host]     : .NET 9.0.4 (9.0.425.16305), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
  Job-SEDLIK : .NET 9.0.4 (9.0.425.16305), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI

Job=Job-SEDLIK  EnvironmentVariables=DOTNET_GCDynamicAdaptationMode=0  Runtime=.NET 9.0
Toolchain=net90  InvocationCount=Default  IterationTime=350ms
MaxIterationCount=15  MinIterationCount=5  WarmupCount=6
Quotes=False  Reader=String  Error=0.0242 ms
StdDev=0.0086 ms

| Method    | Scope | Rows  | Mean     | Ratio | MB | MB/s    | ns/row | Allocated | Alloc Ratio |
|---------- |------ |------ |---------:|------:|---:|--------:|-------:|----------:|------------:|
| Sep______ | Row   | 50000 | 1.408 ms |  1.00 | 29 | 20726.9 |   28.2 |   1.01 KB |        1.00 |
```

```nasm
G_M000_IG05:                ;; offset=0x009C
       cmp      rsi, rbp
       jb       G_M000_IG39
       mov      edi, r9d
       lea      rdi, bword ptr [r10+2*rdi]
       vmovups  zmm4, zmmword ptr [rdi]
       vpmovuswb zmm4, zmm4
       vpcmpeqb ymm5, ymm4, ymm0
       vpcmpeqb ymm6, ymm4, ymm1
       vpcmpeqb ymm7, ymm4, ymm2
       vpcmpeqb ymm4, ymm4, ymm3
       vpternlogd ymm5, ymm4, ymm6, -2
       vpor     ymm6, ymm5, ymm7
       vpmovmskb r15d, ymm6
       mov      r15d, r15d
       test     r15, r15
       je       SHORT G_M000_IG03
       vpmovmskb r13d, ymm4
       mov      r13d, r13d
       lea      r12, [r15+r8]
       cmp      r13, r12
       je       G_M000_IG43

G_M000_IG06:                ;; offset=0x00F3
       vpmovmskb ecx, ymm5
       mov      ecx, ecx
       cmp      rcx, r12
       je       G_M000_IG22

G_M000_IG07:                ;; offset=0x0102
       xor      ecx, ecx
```