### PR TITLE
Add TryAdd to SepWriterHeader

### DIFF
--- a/src/Sep.Test/SepWriterHeaderTest.cs
+++ b/src/Sep.Test/SepWriterHeaderTest.cs
@@ -162,7 +162,7 @@ public class SepWriterHeaderTest
         var e = Assert.ThrowsException<ArgumentException>(() => header.Add("A"));
         Assert.AreEqual("Column name 'A' already exists (Parameter 'colName')", e.Message);
     }
-    
+
     [TestMethod]
     public void SepWriterHeaderTest_TryAdd_Once_Is_True()
     {
@@ -171,7 +171,7 @@ public class SepWriterHeaderTest
 
         Assert.IsTrue(header.TryAdd("A"));
     }
-    
+
     [TestMethod]
     public void SepWriterHeaderTest_TryAdd_Twice_Is_False()
     {
@@ -181,7 +181,7 @@ public class SepWriterHeaderTest
 
         Assert.IsFalse(header.TryAdd("A"));
     }
-    
+
     [TestMethod]
     public void SepWriterHeaderTest_TryAdd_After_Written_Is_False()
     {
@@ -189,7 +189,7 @@ public class SepWriterHeaderTest
         var header = writer.Header;
         header.Add("A");
         header.Write();
-        
+
         Assert.IsFalse(header.TryAdd("B"));
     }
 

--- a/src/Sep.Test/SepWriterHeaderTest.cs
+++ b/src/Sep.Test/SepWriterHeaderTest.cs
@@ -181,6 +181,17 @@ public class SepWriterHeaderTest
 
         Assert.IsFalse(header.TryAdd("A"));
     }
+    
+    [TestMethod]
+    public void SepWriterHeaderTest_TryAdd_After_Written_Is_False()
+    {
+        using var writer = CreateWriter();
+        var header = writer.Header;
+        header.Add("A");
+        header.Write();
+        
+        Assert.IsFalse(header.TryAdd("B"));
+    }
 
     [TestMethod]
     public void SepWriterHeaderTest_Add_After_Written_Throws()

--- a/src/Sep.Test/SepWriterHeaderTest.cs
+++ b/src/Sep.Test/SepWriterHeaderTest.cs
@@ -162,6 +162,25 @@ public class SepWriterHeaderTest
         var e = Assert.ThrowsException<ArgumentException>(() => header.Add("A"));
         Assert.AreEqual("Column name 'A' already exists (Parameter 'colName')", e.Message);
     }
+    
+    [TestMethod]
+    public void SepWriterHeaderTest_Try_Add_Once_Is_True()
+    {
+        using var writer = CreateWriter();
+        var header = writer.Header;
+
+        Assert.IsTrue(header.TryAdd("A"));
+    }
+    
+    [TestMethod]
+    public void SepWriterHeaderTest_Try_Add_Twice_Is_False()
+    {
+        using var writer = CreateWriter();
+        var header = writer.Header;
+        header.Add("A");
+
+        Assert.IsFalse(header.TryAdd("A"));
+    }
 
     [TestMethod]
     public void SepWriterHeaderTest_Add_After_Written_Throws()

--- a/src/Sep.Test/SepWriterHeaderTest.cs
+++ b/src/Sep.Test/SepWriterHeaderTest.cs
@@ -164,7 +164,7 @@ public class SepWriterHeaderTest
     }
     
     [TestMethod]
-    public void SepWriterHeaderTest_Try_Add_Once_Is_True()
+    public void SepWriterHeaderTest_TryAdd_Once_Is_True()
     {
         using var writer = CreateWriter();
         var header = writer.Header;
@@ -173,7 +173,7 @@ public class SepWriterHeaderTest
     }
     
     [TestMethod]
-    public void SepWriterHeaderTest_Try_Add_Twice_Is_False()
+    public void SepWriterHeaderTest_TryAdd_Twice_Is_False()
     {
         using var writer = CreateWriter();
         var header = writer.Header;

--- a/src/Sep/SepWriterHeader.cs
+++ b/src/Sep/SepWriterHeader.cs
@@ -45,6 +45,20 @@ public sealed class SepWriterHeader
         _writer.AddCol(colName);
     }
 
+    public bool TryAdd(string colName)
+    {
+        if (_writer._headerWrittenOrSkipped)
+        {
+            return false;
+        }
+        if (_writer._colNameToCol.ContainsKey(colName))
+        {
+            return false;
+        }
+        _writer.AddCol(colName);
+        return true;
+    }
+
     public void Write() => _writer.WriteHeader();
     public ValueTask WriteAsync(CancellationToken cancellationToken = default) =>
         _writer.WriteHeaderAsync(cancellationToken);


### PR DESCRIPTION
There are situations where the user of the library doesn't care if the column already exists. Instead of always throwing an exception an alternative would be to implement a try pattern to ignore additions that would normally cause an error.

The field `SepWriter._colNameToCol` is only available internally, so the user can not check if a column already exists without an external data structure or catching the exception from `SepWriterHeader.Add`.