### PR TITLE
Set Sep.Min to ASCII 31 to allow Unit Separator

### DIFF
--- a/src/Sep.Test/SepTest.cs
+++ b/src/Sep.Test/SepTest.cs
@@ -77,7 +77,7 @@ public class SepTest
     public void SepTest_Separator_LessThanMin_Throws()
     {
         var separator = (char)(Sep.Min.Separator - 1);
-        var expectedMessage = "'\u001f':31 is not supported. Must be inside [32..126]. (Parameter 'separator')";
+        var expectedMessage = "'\u001e':30 is not supported. Must be inside [31..126]. (Parameter 'separator')";
         AssertSeparatorThrows<ArgumentOutOfRangeException>(separator, expectedMessage);
     }
 
@@ -85,7 +85,7 @@ public class SepTest
     public void SepTest_Separator_GreaterThanMax_Throws()
     {
         var separator = (char)(Sep.Max.Separator + 1);
-        var expectedMessage = "'\u007f':127 is not supported. Must be inside [32..126]. (Parameter 'separator')";
+        var expectedMessage = "'\u007f':127 is not supported. Must be inside [31..126]. (Parameter 'separator')";
         AssertSeparatorThrows<ArgumentOutOfRangeException>(separator, expectedMessage);
     }
 
@@ -93,7 +93,7 @@ public class SepTest
     public void SepTest_Separator_LineFeed_Throws()
     {
         var separator = '\n';
-        var expectedMessage = "'\n':10 is not supported. Must be inside [32..126]. (Parameter 'separator')";
+        var expectedMessage = "'\n':10 is not supported. Must be inside [31..126]. (Parameter 'separator')";
         AssertSeparatorThrows<ArgumentOutOfRangeException>(separator, expectedMessage);
     }
 
@@ -101,7 +101,7 @@ public class SepTest
     public void SepTest_Separator_CarriageReturn_Throws()
     {
         var separator = '\r';
-        var expectedMessage = "'\r':13 is not supported. Must be inside [32..126]. (Parameter 'separator')";
+        var expectedMessage = "'\r':13 is not supported. Must be inside [31..126]. (Parameter 'separator')";
         AssertSeparatorThrows<ArgumentOutOfRangeException>(separator, expectedMessage);
     }
 

--- a/src/Sep/Sep.cs
+++ b/src/Sep/Sep.cs
@@ -5,7 +5,7 @@ namespace nietras.SeparatedValues;
 
 public readonly record struct Sep
 {
-    const char _min = (char)32;
+    const char _min = (char)31;
     const char _max = (char)126;
 
     readonly char _separator;


### PR DESCRIPTION
Fix #318 