### PR TITLE
Migrate tests to Microsoft.Testing.Platform

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Build
         run: dotnet build -c ${{ matrix.configuration }} --no-restore
       - name: Test
-        run: dotnet test -c ${{ matrix.configuration }} --no-build --no-restore --verbosity normal --collect:"XPlat Code Coverage" -p:TestTfmsInParallel=true --logger GitHubActions -- /Parallel
+        run: dotnet test -c ${{ matrix.configuration }} --no-build --no-restore --verbosity normal -p:TestTfmsInParallel=true --coverage --coverage-output-format cobertura --report-github
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:

--- a/global.json
+++ b/global.json
@@ -3,5 +3,8 @@
     "version": "10.0.400",
     "rollForward": "latestPatch",
     "allowPrerelease": false
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
   }
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -48,6 +48,11 @@
     <!--<DefineConstants Condition="'$(Configuration)'=='Release'">$(DefineConstants);SEPUSESTRUCTFORPARSERSFORDISASMO</DefineConstants>-->
   </PropertyGroup>
 
+  <PropertyGroup Condition="$(MSBuildProjectName.EndsWith('Test'))">
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
   <ItemGroup>
     <AssemblyAttribute Include="System.CLSCompliantAttribute">
       <_Parameter1>false</_Parameter1>

--- a/src/Sep.Test/Sep.Test.csproj
+++ b/src/Sep.Test/Sep.Test.csproj
@@ -16,10 +16,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.9.0" PrivateAssets="all" />
     <PackageReference Include="MSTest" Version="4.3.3" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.5" PrivateAssets="all" />
   </ItemGroup>

--- a/src/Sep.XyzTest/Sep.XyzTest.csproj
+++ b/src/Sep.XyzTest/Sep.XyzTest.csproj
@@ -16,10 +16,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.9.0" PrivateAssets="all" />
     <PackageReference Include="PublicApiGenerator" Version="11.5.4" />
     <PackageReference Include="MSTest" Version="4.3.3" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.5" PrivateAssets="all" />

--- a/test-parsers.ps1
+++ b/test-parsers.ps1
@@ -21,9 +21,9 @@ Try {
     foreach ($parser in $parsers) {
         $env:SEPFORCEPARSER=$parser
         Write-Output "Testing $parser Debug"
-        dotnet test .\src\Sep.Test\Sep.Test.csproj --nologo -c Debug --no-build --no-restore -p:TestTfmsInParallel=true --logger GitHubActions -- /Parallel
+        dotnet test --project .\src\Sep.Test\Sep.Test.csproj -c Debug --no-build --no-restore -p:TestTfmsInParallel=true --report-github
         Write-Output "Testing $parser Release"
-        dotnet test .\src\Sep.Test\Sep.Test.csproj --nologo -c Release --no-build --no-restore -p:TestTfmsInParallel=true --logger GitHubActions -- /Parallel
+        dotnet test --project .\src\Sep.Test\Sep.Test.csproj -c Release --no-build --no-restore -p:TestTfmsInParallel=true --report-github
     }
 } Finally {
     Remove-Item env:SEPFORCEPARSER

--- a/test-x64-x86.ps1
+++ b/test-x64-x86.ps1
@@ -1,9 +1,9 @@
 #!/usr/bin/env pwsh
 Write-Output "Testing Debug X86"
-dotnet test --nologo -c Debug -- RunConfiguration.TargetPlatform=x86 /Parallel
+dotnet test -c Debug --arch x86
 Write-Output "Testing Release X86"
-dotnet test --nologo -c Release -- RunConfiguration.TargetPlatform=x86 /Parallel
+dotnet test -c Release --arch x86
 Write-Output "Testing Debug X64"
-dotnet test --nologo -c Debug -- RunConfiguration.TargetPlatform=x64 /Parallel
+dotnet test -c Debug --arch x64
 Write-Output "Testing Release X64"
-dotnet test --nologo -c Release --collect:"XPlat Code Coverage" -- RunConfiguration.TargetPlatform=x64 /Parallel
+dotnet test -c Release --arch x64 --coverage --coverage-output-format cobertura


### PR DESCRIPTION
## Why

The test suite still depended on VSTest-specific runner configuration and command-line arguments. Moving every test project together to Microsoft.Testing.Platform enables the native .NET 10 test experience, direct executable test runs, and avoids the unsupported mixed-platform state.

## What changed

- Enable the native Microsoft.Testing.Platform runner through `global.json` and shared MSTest runner properties.
- Build both test projects as executables and replace the VSTest coverage collector with the MTP code coverage extension.
- Update GitHub Actions and PowerShell scripts to use MTP coverage, GitHub reporting, and architecture arguments.
- Remove VSTest-only logger, collection, runsettings, and parallel switches.

## Validation

- Release build succeeds with 0 warnings and 0 errors.
- Full MTP suite passes: 2,378 tests, 0 failures, 0 skipped.
- Direct `Sep.XyzTest.exe` execution passes 20 tests.
- Cobertura coverage artifacts are generated successfully.

## Note

`global.json` remains pinned to stable .NET SDK 10.0.400. Local verification used the installed 10.0.400 preview SDK explicitly because the stable SDK was not available on the validation machine.